### PR TITLE
Python analysis scripts

### DIFF
--- a/scripts/code_schema.py
+++ b/scripts/code_schema.py
@@ -1,0 +1,66 @@
+import os
+import json
+
+class ResultData:
+    def __init__(self):
+        self.enums = []
+        self.simple = []
+        self.complex = {}
+
+def dumper(obj):
+    return obj.__dict__
+
+# find project root folder
+repo_root = os.path.abspath(os.getcwd())
+levels = []
+found = False
+while len(levels) < 3:
+    all_files = os.listdir(repo_root)
+    if 'Package.swift' in all_files:
+        found = True
+        break
+    levels.append('..')
+    repo_root = os.path.abspath(os.path.join(repo_root, *levels))
+
+if not found:
+    raise Exception('Could not determine repo root.')
+
+# open and parse code model
+code_model_path = os.path.abspath(os.path.join(repo_root, 'misc', 'codeModel.json'))
+with open(code_model_path, 'r') as json_file:
+    json_obj = json.load(json_file)
+
+# analyze results
+results = ResultData()
+for name, metadata in json_obj['definitions'].items():
+    # find enum values
+    if metadata.get('enum'):
+        results.enums.append(name)
+        continue
+
+    # find items with 'allOf' properties
+    all_of_items = metadata.get('allOf')
+    if all_of_items:
+        for item in metadata.get('allOf', []):
+            parent = item['$ref'].rsplit('/', 1)[1]
+            if parent not in results.complex:
+                results.complex[parent] = {}
+            if parent in results.simple:
+                results.simple.remove(parent)
+            if name in results.simple:
+                results.simple.remove(name)
+            results.complex[parent][name] = []
+    else:
+        results.simple.append(name)
+
+# now go back and up-level any instances of multiple inheritance
+for name, children in results.complex.items():
+    for child in children:
+        # if a complex type is a child of another complex type, move it into that type
+        if child in results.complex:
+            children[child] = results.complex[child]
+            del results.complex[child]
+
+results.simple.sort()
+results.enums.sort()
+print(json.dumps(results, default=dumper, indent=4, sort_keys=True))

--- a/scripts/swift_class_audit.py
+++ b/scripts/swift_class_audit.py
@@ -1,0 +1,58 @@
+import os
+import json
+
+class ItemResult:
+    def __init__(self, name, schema, done):
+        self.name = name
+        self.schema = schema
+        self.done = done
+
+def dumper(obj):
+    return obj.__dict__
+
+# find project root folder
+repo_root = os.path.abspath(os.getcwd())
+levels = []
+found = False
+while len(levels) < 3:
+    all_files = os.listdir(repo_root)
+    if 'Package.swift' in all_files:
+        found = True
+        break
+    levels.append('..')
+    repo_root = os.path.abspath(os.path.join(repo_root, *levels))
+
+if not found:
+    raise Exception('Could not determine repo root.')
+
+# open and parse code model
+code_model_path = os.path.abspath(os.path.join(repo_root, 'misc', 'codeModel.json'))
+with open(code_model_path, 'r') as json_file:
+    json_obj = json.load(json_file)
+
+swift_code_path = os.path.abspath(os.path.join(repo_root, 'src', 'AutorestSwift', 'Models'))
+
+# analyze results
+results = []
+for name, metadata in json_obj['definitions'].items():
+    schema = 'struct'
+    if metadata.get('enum'):
+        schema = 'enum'
+
+    swift_name = "{}.swift".format(name)
+    swift_path = os.path.join(swift_code_path, swift_name)
+    try:
+        with open(swift_path, 'r') as swift_file:
+            results.append(ItemResult(name=name, schema=schema, done=True))
+    except IOError:
+        results.append(ItemResult(name=name, schema=schema, done=False))
+
+print(json.dumps(results, default=dumper, indent=4, sort_keys=True))
+
+finished = [r for r in results if r.done]
+unfinished = [r for r in results if not r.done]
+finished_count = len(finished)
+unfinished_count = len(unfinished)
+total = finished_count + unfinished_count
+
+print('{} / {} files written ({:.0f}%)'.format(finished_count, total, finished_count * 100.0 / total))


### PR DESCRIPTION
Adds a couple small scripts

1. `swift_class_audit.py` shows which schema definitions we have written Swift classes for and outputs the completion percentage (currently 66%)

2. `code_schema.py` is basically a Python version of `read-code-mode.js` because I actually know Python and don't know Javascript. :)  It separates the schema definitions into a few useful buckets: simple types, enum types and complex types. For the complex types, children of children all get relocated under the parent entry. Here's what the output looks like:

```
{
    "complex": {
        "Metadata": {
            "OperationGroup": [], 
            "Request": [], 
            "Response": {
                "BinaryResponse": [], 
                "SchemaResponse": []
            }
        }, 
        "Protocol": {
            "HttpModel": [], 
            "HttpParameter": [], 
            "HttpRequest": {
                "HttpWithBodyRequest": {
                    "HttpBinaryRequest": [], 
                    "HttpMultiPartRequest": []
                }
            }, 
            "HttpResponse": {
                "HttpBinaryResponse": []
            }
        }, 
        "Schema": {
            "AnySchema": [], 
            "BinarySchema": [], 
            "ComplexSchema": {
                "DictionarySchema": [], 
                "ObjectSchema": [], 
                "OrSchema": []
            }, 
            "ConstantSchema": [], 
            "GroupSchema": [], 
            "NotSchema": [], 
            "ODataQuerySchema": [], 
            "ValueSchema": {
                "ArraySchema": [], 
                "ByteArraySchema": [], 
                "ChoiceSchema": [], 
                "ConditionalSchema": [], 
                "FlagSchema": [], 
                "PrimitiveSchema": {
                    "BooleanSchema": [], 
                    "CharSchema": [], 
                    "CredentialSchema": [], 
                    "DateSchema": [], 
                    "DateTimeSchema": [], 
                    "DurationSchema": [], 
                    "NumberSchema": [], 
                    "StringSchema": [], 
                    "TimeSchema": [], 
                    "UnixTimeSchema": [], 
                    "UriSchema": [], 
                    "UuidSchema": []
                }, 
                "SealedChoiceSchema": [], 
                "SealedConditionalSchema": []
            }, 
            "XorSchema": []
        }, 
        "SchemaUsage": {
            "GroupSchema": [], 
            "ObjectSchema": []
        }, 
        "SerializationFormat": {
            "XmlSerlializationFormat": []
        }, 
        "Value": {
            "Parameter": {
                "VirtualParameter": []
            }, 
            "Property": {
                "GroupProperty": []
            }
        }
    }, 
    "enums": [
        "AllSchemaTypes", 
        "CompoundSchemaTypes", 
        "Default", 
        "HttpMethod", 
        "ImplementationLocation", 
        "KnownMediaType", 
        "ObjectSchemaTypes", 
        "ParameterLocation", 
        "PathEncodingStyle", 
        "PrimitiveSchemaTypes", 
        "QueryEncodingStyle", 
        "SchemaContext", 
        "SchemaType", 
        "Scheme", 
        "SecurityType", 
        "SerializationStyle", 
        "StatusCode", 
        "ValueSchemaTypes"
    ], 
    "simple": [
        "APIKeySecurityScheme", 
        "ApiVersion", 
        "ApiVersions", 
        "AuthorizationCodeOAuthFlow", 
        "BearerHTTPSecurityScheme", 
        "CSharpLanguage", 
        "ChoiceValue", 
        "ClientCredentialsFlow", 
        "ConditionalValue", 
        "ConstantType", 
        "ConstantValue", 
        "Contact", 
        "Deprecation", 
        "Dictionary<ApiVersion>", 
        "Dictionary<ComplexSchema>", 
        "Dictionary<any>", 
        "Dictionary<string>", 
        "Discriminator", 
        "Example", 
        "Extensions", 
        "ExternalDocumentation", 
        "FlagValue", 
        "HTTPSecurityScheme", 
        "HttpHeader", 
        "HttpMultipartRequest", 
        "ImplicitOAuthFlow", 
        "Info", 
        "Language", 
        "Languages", 
        "License", 
        "NonBearerHTTPSecurityScheme", 
        "OAuth2SecurityScheme", 
        "OAuthFlows", 
        "OpenIdConnectSecurityScheme", 
        "Operation", 
        "PasswordOAuthFlow", 
        "Protocols", 
        "Relations", 
        "SchemaUsage", 
        "Schemas", 
        "Security", 
        "SecurityRequirement", 
        "SecurityScheme", 
        "SerializationFormats", 
        "email", 
        "uri"
    ]
}
```

You can run either script with `python script_name.py`