### PR TITLE
Enable extensions property

### DIFF
--- a/src/AutorestSwift/Models/ChoiceValue.swift
+++ b/src/AutorestSwift/Models/ChoiceValue.swift
@@ -23,6 +23,5 @@ public struct ChoiceValue: Codable {
     public let value: String // StringOrNumberOrBoolean
 
     /// Additional metadata extensions dictionary
-    // TODO: Not Codable
-    // public let extensions: Dictionary<AnyHashable, Codable>?
+    public let extensions: [String: Bool]?
 }

--- a/src/AutorestSwift/Models/CodeModel.swift
+++ b/src/AutorestSwift/Models/CodeModel.swift
@@ -16,6 +16,5 @@ public struct CodeModel: Codable {
     let security: Security
     let language: Languages
     let `protocol`: Protocols
-    // TODO: Not Codable
-    // let extensions: Dictionary<AnyHashable, Codable>?
+    let extensions: [String: Bool]?
 }

--- a/src/AutorestSwift/Models/ConditionalValue.swift
+++ b/src/AutorestSwift/Models/ConditionalValue.swift
@@ -21,6 +21,5 @@ public struct ConditionalValue: Codable {
     public let source: String // StringOrNumberOrBoolean
 
     /// Additional metadata extensions dictionary
-    // TODO: Not Codable
-    // public let extensions: Dictionary<AnyHashable, Codable>?
+    public let extensions: [String: Bool]?
 }

--- a/src/AutorestSwift/Models/ConstantValue.swift
+++ b/src/AutorestSwift/Models/ConstantValue.swift
@@ -16,6 +16,5 @@ public struct ConstantValue: Codable {
     public let value: String
 
     /// Additional metadata extensions dictionary
-    // TODO: Not Codable
-    // public let extensions: Dictionary<AnyHashable, Codable>?
+    public let extensions: [String: Bool]?
 }

--- a/src/AutorestSwift/Models/Contact.swift
+++ b/src/AutorestSwift/Models/Contact.swift
@@ -19,6 +19,5 @@ public struct Contact: Codable {
     public let email: String?
 
     /// additional metadata extensions dictionary
-    // TODO: Not Codable
-    // public let extensions: Dictionary<AnyHashable, Codable>?
+    public let extensions: [String: Bool]?
 }

--- a/src/AutorestSwift/Models/ExternalDocumentation.swift
+++ b/src/AutorestSwift/Models/ExternalDocumentation.swift
@@ -15,6 +15,5 @@ public struct ExternalDocumentation: Codable {
     public let url: String
 
     /// Additional metadata extensions dictionary
-    // TODO: Not Codable
-    // public let extensions: Dictionary<AnyHashable, Codable>?
+    public let extensions: [String: Bool]?
 }

--- a/src/AutorestSwift/Models/FlagValue.swift
+++ b/src/AutorestSwift/Models/FlagValue.swift
@@ -15,6 +15,5 @@ public struct FlagValue: Codable {
     public let value: Int
 
     /// Additional metadata extensions dictionary
-    // TODO: Not Codable
-    // public let extensions: Dictionary<AnyHashable, Codable>?
+    public let extensions: [String: Bool]?
 }

--- a/src/AutorestSwift/Models/HttpHeader.swift
+++ b/src/AutorestSwift/Models/HttpHeader.swift
@@ -10,6 +10,5 @@ import Foundation
 public struct HttpHeader: Codable {
     public let header: String
     public let schema: Schema
-    // TODO: Not Codable
-    // public let extensions: Dictionary<String, Codable>?
+    public let extensions: [String: Bool]?
 }

--- a/src/AutorestSwift/Models/Info.swift
+++ b/src/AutorestSwift/Models/Info.swift
@@ -28,6 +28,5 @@ public struct Info: Codable {
     public let externalDocs: ExternalDocumentation?
 
     /// additional metadata extensions dictionary
-    // TODO: Not Codable
-    // public let extensions: Dictionary<AnyHashable, Codable>?
+    public let extensions: [String: Bool]?
 }

--- a/src/AutorestSwift/Models/License.swift
+++ b/src/AutorestSwift/Models/License.swift
@@ -16,6 +16,5 @@ public struct License: Codable {
     public let url: String?
 
     /// additional metadata extensions dictionary
-    // TODO: Not Codable
-    // public let extensions: Dictionary<AnyHashable, Codable>?
+    public let extensions: [String: Bool]?
 }

--- a/src/AutorestSwift/Models/Metadata.swift
+++ b/src/AutorestSwift/Models/Metadata.swift
@@ -21,6 +21,5 @@ public struct Metadata: MetadataInterface {
     public let `protocol`: Protocols
 
     /// additional metadata extensions dictionary
-    // TODO: Not Codable
-    // public let extensions: Dictionary<AnyHashable, Codable>?
+    public let extensions: [String: Bool]?
 }

--- a/src/AutorestSwift/Models/Operation.swift
+++ b/src/AutorestSwift/Models/Operation.swift
@@ -49,8 +49,7 @@ public struct Operation: Codable {
     public let `protocol`: Protocols
 
     /// additional metadata extensions dictionary
-    // TODO: Not Codable
-    // public let extensions: Dictionary<AnyHashable, Codable>?
+    public let extensions: [String: Bool]?
 
     public enum CodingKeys: String, CodingKey {
         case parameters, signatureParameters, requests, responses, exceptions, profile, summary, apiVersions,

--- a/src/AutorestSwift/Models/Parameter.swift
+++ b/src/AutorestSwift/Models/Parameter.swift
@@ -10,7 +10,7 @@ import Foundation
 public typealias Parameter = Compose<ParameterProperty, Value>
 
 /// A definition of an discrete input for an operation
-public struct ParameterProperty: Codable {
+public class ParameterProperty: Codable {
     /// suggested implementation location for this parameter
     public let implementation: ImplementationLocation?
 
@@ -18,6 +18,5 @@ public struct ParameterProperty: Codable {
     public let flattened: Bool?
 
     /// when a parameter is grouped into another, this will tell where the parameter got grouped into
-    // FIXME: Recursive cycle
-    // public let groupedBy: Parameter?
+    public let groupedBy: Parameter?
 }

--- a/src/AutorestSwift/Models/Schema.swift
+++ b/src/AutorestSwift/Models/Schema.swift
@@ -42,7 +42,7 @@ public class Schema: Codable {
     public let `protocol`: Protocols
 
     public let properties: [Property]?
+
     /// Additional metadata extensions dictionary
-    // TODO: Not Codable
-    // public let extensions: Dictionary<AnyHashable, Codable>?
+    public let extensions: [String: Bool]?
 }

--- a/src/AutorestSwift/Models/SerializationFormat.swift
+++ b/src/AutorestSwift/Models/SerializationFormat.swift
@@ -8,6 +8,5 @@
 import Foundation
 
 public struct SerializationFormat: Codable {
-    // TODO: Not Codable
-    // public let extensions: Dictionary<AnyHashable, Codable>?
+    public let extensions: [String: Bool]?
 }

--- a/src/AutorestSwift/Models/Value.swift
+++ b/src/AutorestSwift/Models/Value.swift
@@ -46,6 +46,5 @@ public class Value: Codable {
     public let `protocol`: Protocols
 
     /// Additional metadata extensions dictionary
-    // TODO: Not Codable
-    // public let extensions: Dictionary<AnyHashable, Codable>?
+    public let extensions: [String: Bool]?
 }


### PR DESCRIPTION
This assumes `[String: Bool]` since that is what our current Swaggers are using, but really, these could also be `[String: String]` and potentially other things, so this is likely to need to be reworked.