### PR TITLE
Refactor language and languages

### DIFF
--- a/src/AutorestSwift/Models/Simple/Language.swift
+++ b/src/AutorestSwift/Models/Simple/Language.swift
@@ -10,14 +10,24 @@ import Foundation
 /// The bare-minimum fields for per-language metadata on a given aspect
 public class Language: Codable {
     /// name used in actual implementation
-    public let name: String
+    public var name: String
 
     /// description text - describes this node.
-    public let description: String
+    public var description: String
 
-    public let summary: String?
+    public var summary: String?
 
-    public let serializedName: String?
+    public var serializedName: String?
 
-    public let namespace: String?
+    public var namespace: String?
+
+    // MARK: Initializers
+
+    public init(from original: Language) {
+        self.name = original.name
+        self.description = original.description
+        self.summary = original.summary
+        self.serializedName = original.serializedName
+        self.namespace = original.namespace
+    }
 }

--- a/src/AutorestSwift/Models/Simple/Languages.swift
+++ b/src/AutorestSwift/Models/Simple/Languages.swift
@@ -11,29 +11,31 @@ import Foundation
 public class Languages: Codable {
     public let `default`: Language
 
-    public let csharp: CSharpLanguage?
+    // these properties we can set
+    private var _swift: Language?
 
-    public let python: Language?
+    public var swift: Language {
+        get {
+            if _swift == nil {
+                _swift = Language(from: `default`)
+            }
+            return _swift!
+        }
+        set {
+            if _swift == nil {
+                _swift = Language(from: `default`)
+            }
+            _swift = newValue
+        }
+    }
 
-    public let ruby: Language?
+    public var objectiveC: Language?
 
-    public let go: Language?
+    // MARK: Codable
 
-    public let typescript: Language?
-
-    public let javascript: Language?
-
-    public let powershell: Language?
-
-    public let java: Language?
-
-    public let c: Language?
-
-    public let cpp: Language?
-
-    public let swift: Language?
-
-    public let objectiveC: Language?
-
-    public let sputnik: Language?
+    enum CodingKeys: String, CodingKey {
+        case `default`
+        case _swift = "swift"
+        case objectiveC
+    }
 }


### PR DESCRIPTION
This PR refactors `Language` to have a copy constructor and `Languages` to eliminate languages we don't care about and add behavior so that calling `language.swift.foo` will always succeed, copying the information in `language.default` if needed. This will allow us to write code generation using `language.swift` before the naming pass of the generator is complete.