### PR TITLE
Refactor core

### DIFF
--- a/src/AutorestSwift/Code Generator/CodeGenerationError.swift
+++ b/src/AutorestSwift/Code Generator/CodeGenerationError.swift
@@ -1,0 +1,15 @@
+//
+//  CodeGenerationError.swift
+//  
+//
+//  Created by Travis Prescott on 7/21/20.
+//
+
+import Foundation
+
+/// Error codes thrown during code generation
+enum CodeGenerationError {
+
+    /// A general error has occurred.
+    case general(String)
+}

--- a/src/AutorestSwift/Code Generator/CodeGenerator.swift
+++ b/src/AutorestSwift/Code Generator/CodeGenerator.swift
@@ -1,0 +1,16 @@
+//
+//  CodeGenerator.swift
+//  
+//
+//  Created by Travis Prescott on 7/21/20.
+//
+
+import Foundation
+
+/// Common protocol for language code generators.
+protocol CodeGenerator {
+    // TODO: Promote methods from SwiftGenerator to here for use on something like
+    // and ObjectiveC generator.
+
+    var model: CodeModel { get }
+}

--- a/src/AutorestSwift/Code Generator/CodeNamer.swift
+++ b/src/AutorestSwift/Code Generator/CodeNamer.swift
@@ -1,0 +1,11 @@
+//
+//  CodeNamer.swift
+//  
+//
+//  Created by Travis Prescott on 7/21/20.
+//
+
+import Foundation
+
+/// Common protocol for language code namers.
+protocol CodeNamer {}

--- a/src/AutorestSwift/Code Generator/Logger.swift
+++ b/src/AutorestSwift/Code Generator/Logger.swift
@@ -1,0 +1,41 @@
+//
+//  Logger.swift
+//  
+//
+//  Created by Travis Prescott on 7/21/20.
+//
+
+import Foundation
+import os.log
+
+class Logger {
+
+    // MARK: Properties
+
+    let name: String
+
+    var loggers: [String: OSLog]
+
+    // MARK: Initializers
+
+    init(withName name: String) {
+        self.name = name
+        loggers = [String: OSLog]()
+    }
+
+    // MARK: Methods
+
+    func log(_ message: @autoclosure @escaping () -> String?, category: String = "default", level: OSLogType = .default) {
+        guard let msg = message() else {
+            os_log("Unable to issue log message")
+            return
+        }
+        if let logger = loggers[category] {
+            os_log("%@", log: logger, type: level, msg)
+        } else {
+            let logger = OSLog(subsystem: name, category: category)
+            loggers[category] = logger
+            os_log("%@", log: logger, type: level, msg)
+        }
+    }
+}

--- a/src/AutorestSwift/Code Generator/Manager.swift
+++ b/src/AutorestSwift/Code Generator/Manager.swift
@@ -1,0 +1,122 @@
+//
+//  Manager.swift
+//  
+//
+//  Created by Travis Prescott on 7/21/20.
+//
+
+import Foundation
+import Yams
+
+/// Handles the configuration and orchestrations of the code generation process
+class Manager {
+
+    // MARK: Properties
+
+    let inputUrl: URL
+
+    let destinationRootUrl: URL
+
+    lazy var logger = Logger(withName: "Autorest.Swift")
+
+    // MARK: Initializers
+
+    init(withInputUrl input: URL, destinationUrl dest: URL) {
+        inputUrl = input
+        // TODO: Make this configurable
+        destinationRootUrl = dest.appendingPathComponent("generated").appendingPathComponent("sdk")
+        ensureExists(folder: destinationRootUrl)
+    }
+
+    // MARK: Methods
+
+    func run() throws {
+        let model = try loadModel()
+
+        // Determine Swift names for all model objects
+        let namer = SwiftNamer(withModel: model)
+        try namer.process()
+
+        // Generate Swift code files
+        let generator = SwiftGenerator(withModel: model)
+        try generator.generate()
+    }
+
+    /// Decodes the YAML code model file into Swift objects and evaluates model consistency
+    private func loadModel() throws -> CodeModel {
+
+        // decode YAML to model
+        let decoder = YAMLDecoder()
+        var yamlString = try String(contentsOf: inputUrl)
+        // TODO: Remove when issue (https://github.com/Azure/autorest.swift/issues/47) is fixed.
+        // Replaces empty string with a single space.
+        yamlString = yamlString.replacingOccurrences(of: ": ''", with: ": ' '")
+        let model = try decoder.decode(CodeModel.self, from: yamlString)
+
+        check(model: model, against: yamlString)
+
+        return model
+    }
+
+    /// Check model for consistency and save debugging files if inconsistent
+    private func check(model: CodeModel, against yamlString: String) {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+
+        var beforeJsonString: String? = nil
+        var afterJsonString: String? = nil
+
+        // get JSON representation of YAML
+        if let beforeJson = try? Yams.load(yaml: yamlString) {
+            do {
+                let beforeJsonData = try JSONSerialization.data(
+                    withJSONObject: beforeJson,
+                    options: [.sortedKeys, .prettyPrinted]
+                )
+                beforeJsonString = String(data: beforeJsonData, encoding: .utf8)
+            } catch {
+                logger.log(error.localizedDescription, level: .error)
+            }
+        }
+
+        // convert model to JSON
+        if let afterJsonData = try? encoder.encode(model) {
+            afterJsonString = String(data: afterJsonData, encoding: .utf8)
+        }
+
+        // If JSON strings don't match, there must be a problem in the modeling.
+        // Dump both files so they can be diffed.
+        if beforeJsonString != afterJsonString {
+            let beforeJsonUrl = destinationRootUrl.appendingPathComponent("before.json")
+            let afterJsonUrl = destinationRootUrl.appendingPathComponent("after.json")
+            do {
+                try beforeJsonString?.write(to: beforeJsonUrl, atomically: true, encoding: .utf8)
+                try afterJsonString?.write(to: afterJsonUrl, atomically: true, encoding: .utf8)
+                logger.log("Discrepancies found in round-tripped code model. Run a diff on 'before.json' and 'after.json' to troubleshoot.")
+            } catch {
+                logger.log("Discrepancies found in round-tripped code model. Error saving files: \(error.localizedDescription)", level: .error)
+            }
+        } else if beforeJsonString == nil || afterJsonString == nil {
+            logger.log("Errors found trying to decode models. Please check your Swagger file.", level: .error)
+        } else {
+            logger.log("Model file check: OK", level: .info)
+        }
+    }
+
+    private func ensureExists(folder: URL) {
+        let fileManager = FileManager.default
+
+        if let existing = try? folder.resourceValues(forKeys: [.isDirectoryKey]) {
+            if !existing.isDirectory! {
+                fatalError("Path exists but is not a folder!")
+            }
+        } else {
+            // Path does not exist so let us create it
+            do {
+                try fileManager.createDirectory(atPath: folder.path, withIntermediateDirectories: true, attributes: nil)
+            } catch {
+                logger.log(error.localizedDescription, level: .error)
+            }
+        }
+    }
+}

--- a/src/AutorestSwift/Code Generator/Manager.swift
+++ b/src/AutorestSwift/Code Generator/Manager.swift
@@ -108,7 +108,9 @@ class Manager {
 
         if let existing = try? folder.resourceValues(forKeys: [.isDirectoryKey]) {
             if !existing.isDirectory! {
-                fatalError("Path exists but is not a folder!")
+                let err = "Path exists but is not a folder!"
+                logger.log(err, level: .error)
+                fatalError(err)
             }
         } else {
             // Path does not exist so let us create it

--- a/src/AutorestSwift/Code Generator/SwiftGenerator.swift
+++ b/src/AutorestSwift/Code Generator/SwiftGenerator.swift
@@ -1,0 +1,29 @@
+//
+//  SwiftGenerator.swift
+//  
+//
+//  Created by Travis Prescott on 7/21/20.
+//
+
+import Foundation
+
+/// Class used to generate Swift code
+class SwiftGenerator: CodeGenerator {
+
+    // MARK: Properties
+
+    let model: CodeModel
+
+    // MARK: Initializers
+
+    init(withModel model: CodeModel) {
+        self.model = model
+    }
+
+    // MARK: Methods
+
+    /// Begin code generation process
+    func generate() throws {
+        // TODO: Begin code generation process
+    }
+}

--- a/src/AutorestSwift/Code Generator/SwiftNamer.swift
+++ b/src/AutorestSwift/Code Generator/SwiftNamer.swift
@@ -1,0 +1,28 @@
+//
+//  SwiftNamer.swift
+//  
+//
+//  Created by Travis Prescott on 7/21/20.
+//
+
+import Foundation
+
+class SwiftNamer: CodeNamer {
+
+    // MARK: Properties
+
+    let model: CodeModel
+
+    // MARK: Initializers
+
+    init(withModel model: CodeModel) {
+        self.model = model
+    }
+
+    // MARK: Methods
+
+    /// Begin naming process
+    func process() throws {
+        // TODO: Fill in naming logic here
+    }
+}

--- a/src/AutorestSwift/main.swift
+++ b/src/AutorestSwift/main.swift
@@ -1,45 +1,13 @@
 import Foundation
-import Yams
+import os.log
 
-guard let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
-else { fatalError("Unable to find Documents directory.") }
-
+guard let documentsUrl =  FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+    fatalError("Unabled to locate Documents directory.")
+}
 let sourceUrl = documentsUrl.appendingPathComponent("code-model-v4-2.yaml")
-let beforeJsonUrl = documentsUrl.appendingPathComponent("before.json")
-let afterJsonUrl = documentsUrl.appendingPathComponent("after.json")
-
+let manager = Manager(withInputUrl: sourceUrl, destinationUrl: documentsUrl)
 do {
-    var yamlString = try String(contentsOf: sourceUrl)
-
-    // TODO: Remove when issue (https://github.com/Azure/autorest.swift/issues/47) is fixed. Replaces empty string with a single space.
-    yamlString = yamlString.replacingOccurrences(of: ": ''", with: ": ' '")
-
-    let encoder = JSONEncoder()
-    encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
-
-    // convert YAML to JSON and save as before
-    if let beforeJson = try Yams.load(yaml: yamlString) {
-        let beforeJsonData = try JSONSerialization.data(
-            withJSONObject: beforeJson,
-            options: [.sortedKeys, .prettyPrinted]
-        )
-        try beforeJsonData.write(to: beforeJsonUrl)
-    }
-
-    // decode YAML to model
-    let decoder = YAMLDecoder()
-    let model = try decoder.decode(CodeModel.self, from: yamlString)
-
-    // convert model to JSON
-    let afterJsonData = try encoder.encode(model)
-    try afterJsonData.write(to: afterJsonUrl)
+    try manager.run()
 } catch {
     print(error)
-}
-
-internal func decodeCodeModel(fromYamlNode node: Node) throws -> CodeModel {
-    let nodeString = try Yams.serialize(node: node)
-    print(nodeString)
-    let codeModel = try YAMLDecoder().decode(CodeModel.self, from: nodeString)
-    return codeModel
 }


### PR DESCRIPTION
Refactors `swift.main` to be more object oriented and facilitate work on parallel paths.

- `before.json` and `after.json` are only generated if there are differences. All files will be placed in the `Documents/generated/sdk/` folder.
- Adds a logger class instead of relying on print statements.