### PR TITLE
Add basic CI pipeline configuration

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -8,5 +8,5 @@ jobs:
       - script: sudo xcode-select --switch /Applications/Xcode_11.5.app
         displayName: 'Use Xcode 11.5'
 
-      - script: swift build
-        displayName: 'Build'
+      - script: npm install
+        displayName: Build

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -1,0 +1,12 @@
+jobs:
+  - job: CI
+
+    pool:
+      vmImage: 'macOS-10.15'
+
+    steps:
+      - script: sudo xcode-select --switch /Applications/Xcode_11.5.app
+        displayName: 'Use Xcode 11.5'
+
+      - script: swift build
+        displayName: 'Build'

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@autorest/swift",
+  "version": "0.1.0",
+  "description": "AutoRest generator extension for the Swift programming language.",
+  "scripts": {
+    "start": "swift run AutorestSwift",
+    "install": "swift build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Azure/autorest.swift/"
+  },
+  "readme": "https://github.com/Azure/autorest.swift/blob/master/README.md",
+  "keywords": [
+    "autorest",
+    "swift"
+  ],
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Azure/autorest.swift/issues"
+  },
+  "homepage": "https://github.com/Azure/autorest.swift/blob/master/README.md",
+  "dependencies": {
+    "@azure-tools/extension": "^3.0.249"
+  },
+  "devDependencies": {
+    "@autorest/autorest": "^3.0.0",
+    "@microsoft.azure/autorest.testserver": "2.10.54"
+  }
+}


### PR DESCRIPTION
This change adds a basic CI pipeline configuration and a `package.json` that will later be used for publishing this package to GitHub/`npm` for use with AutoRest.  Here's an example of a successful CI run:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=472695&view=logs&j=6614165d-8168-5766-9db6-f35f537f8e36

Once you're able to hook up the generator to AutoRest (RPC docs still underway) I'll set up a publishing pipeline for dev builds so that folks can try it out.