### PR TITLE
Comment out build step from git_sync.sh

### DIFF
--- a/scripts/git_sync.sh
+++ b/scripts/git_sync.sh
@@ -15,16 +15,17 @@ SDK_REPO_ROOT="/Users/travisprescott/Documents/repos/azure-sdk-for-ios-pr/"
 SDK_PACKAGE_ROOT="/Users/travisprescott/Documents/repos/azure-sdk-for-ios-pr/sdk/secret/"
 SDK_DEST="/Users/travisprescott/Documents/repos/azure-sdk-for-ios-pr/sdk/secret/SecretSDK"
 
-echo
-echo "AutoRest.Swift root: $REPO_ROOT"
-echo
-echo "==~ Building AutoRest.Swift ~=="
-echo
-make build -C $REPO_ROOT
-echo
-echo "==~ Generating SDK ~=="
-echo
-swift run --package-path $REPO_ROOT
+# FIXME: The build step fails when run with makefile.
+#echo
+#echo "AutoRest.Swift root: $REPO_ROOT"
+#echo
+#echo "==~ Building AutoRest.Swift ~=="
+#echo
+#make build -C $REPO_ROOT
+#echo
+#echo "==~ Generating SDK ~=="
+#echo
+#swift run --package-path $REPO_ROOT
 
 # ensure the preview/SecretSDK branch is active
 echo


### PR DESCRIPTION
The build steps always fail anyways, so the only thing this script does it copy the generated code from running the program in XCode to the azure-sdk-for-ios-pr repo.