### PR TITLE
Default Policies are correct

### DIFF
--- a/templates/ServiceClientFile.stencil
+++ b/templates/ServiceClientFile.stencil
@@ -32,7 +32,6 @@ public final class {{ model.name }}: PipelineClient {
         withOptions options: {{ model.name }}Options
     ) throws {
         self.options = options
-        // TODO: Determine the correct policies.
         super.init(
             baseUrl: baseUrl,
             transport: URLSessionTransport(),


### PR DESCRIPTION
Closes #92. The default implementations of these are fine. An auth policy must be passed in to the client constructor. It would not be unheard of to have a hand-written extension providing convenience initializers to create the necessary auth policy, but currently I don't think there's enough information to auto-generate that. 