### PR TITLE
Fix bugs when integrating with Chat service endpoint

### DIFF
--- a/AutorestSwift.xcodeproj/xcuserdata/sacheu.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/AutorestSwift.xcodeproj/xcuserdata/sacheu.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -12,12 +12,12 @@
 		<key>AutorestSwiftPackageDescription.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>10</integer>
+			<integer>9</integer>
 		</dict>
 		<key>AutorestSwiftPackageTests.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>9</integer>
+			<integer>10</integer>
 		</dict>
 		<key>AutorestSwiftTests.xcscheme_^#shared#^_</key>
 		<dict>

--- a/AutorestSwift.xcodeproj/xcuserdata/sacheu.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/AutorestSwift.xcodeproj/xcuserdata/sacheu.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -12,12 +12,12 @@
 		<key>AutorestSwiftPackageDescription.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>9</integer>
+			<integer>10</integer>
 		</dict>
 		<key>AutorestSwiftPackageTests.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>10</integer>
+			<integer>9</integer>
 		</dict>
 		<key>AutorestSwiftTests.xcscheme_^#shared#^_</key>
 		<dict>

--- a/src/AutorestSwift/View Models/KeyValueViewModel.swift
+++ b/src/AutorestSwift/View Models/KeyValueViewModel.swift
@@ -69,10 +69,6 @@ struct KeyValueViewModel {
                 // Convert into String in generated code
                 self.value = "String(\(param.name))"
             }
-        } else if key == "endpoint" {
-            self.value = "baseUrl.absoluteString" // baseUrl is a property of the generated client code
-            self.optional = false
-            self.paramName = nil
         } else {
             self.value = ""
             self.optional = false

--- a/src/AutorestSwift/View Models/KeyValueViewModel.swift
+++ b/src/AutorestSwift/View Models/KeyValueViewModel.swift
@@ -49,7 +49,7 @@ struct KeyValueViewModel {
         - Parameter operation: the operation which this paramter exists.
      */
     init(from param: Parameter, with operation: Operation) {
-        self.key = param.serializedName!
+        self.key = param.serializedName ?? param.name
 
         if let constantSchema = param.schema as? ConstantSchema {
             let isString: Bool = constantSchema.valueType.type == AllSchemaTypes.string

--- a/src/AutorestSwift/View Models/OperationViewModel.swift
+++ b/src/AutorestSwift/View Models/OperationViewModel.swift
@@ -82,12 +82,6 @@ struct OperationViewModel {
         self.name = operationName(for: operation.name)
         self.comment = ViewModelComment(from: operation.description)
 
-        var signatureComments: [String] = []
-        for param in operation.signatureParameters ?? [] where param.description != "" {
-            signatureComments.append("   - \(param.name) : \(param.description)")
-        }
-        self.signatureComment = ViewModelComment(from: signatureComments.joined(separator: "\n"))
-
         var params = OperationParameters()
         var pipelineContext = [KeyValueViewModel]()
 
@@ -153,6 +147,12 @@ struct OperationViewModel {
         signatureParams.forEach {
             signaturePropertyViewModel.append(ParameterViewModel(from: $0))
         }
+
+        var signatureComments: [String] = []
+        for param in signatureParams where param.description != "" {
+            signatureComments.append("   - \(param.name) : \(param.description)")
+        }
+        self.signatureComment = ViewModelComment(from: signatureComments.joined(separator: "\n"))
 
         self.signatureParams = signaturePropertyViewModel
 

--- a/src/AutorestSwift/View Models/RequestViewModel.swift
+++ b/src/AutorestSwift/View Models/RequestViewModel.swift
@@ -30,9 +30,6 @@ import Foundation
 struct RequestViewModel {
     let path: String
     let method: String
-    let knownMediaType: String?
-    let uri: String?
-    let mediaTypes: [String]?
     let objectType: String?
     let objectName: String?
     let hasBody: Bool
@@ -42,12 +39,9 @@ struct RequestViewModel {
         let httpRequest = request.protocol.http as? HttpRequest
         self.path = httpRequest?.path ?? ""
         self.method = httpRequest?.method.rawValue ?? ""
-        self.uri = httpRequest?.uri ?? ""
 
         // load HttpWithBodyRequest specfic properties
         let httpWithBodyRequest = request.protocol.http as? HttpWithBodyRequest
-        self.mediaTypes = httpWithBodyRequest?.mediaTypes ?? []
-        self.knownMediaType = httpWithBodyRequest?.knownMediaType.rawValue ?? ""
 
         // TODO: only support the first signature parameter in Reqest now
         let bodyParams = getBodyParameters(signatureParameters: request.signatureParameters)

--- a/templates/ClientMethodOptionsFile.stencil
+++ b/templates/ClientMethodOptionsFile.stencil
@@ -26,7 +26,7 @@ public struct {{ model.name }}: AzureOptions {
 {% endfor %}
     public init(
     {% for property in model.properties %}
-        {{ property.name }}: {{ property.type }}{{ property.initDefaultValue }},
+        {{ property.name }}: {{ property.type }} {{ property.initDefaultValue }},
     {% endfor %}
         clientRequestId: String? = nil,
         cancellationToken: CancellationToken? = nil

--- a/templates/ModelFile.stencil
+++ b/templates/ModelFile.stencil
@@ -16,7 +16,7 @@ public {{ model.objectType }} {{ model.name }} : Codable {
     {% endfor %}
     public init(
     {% for property in model.properties %}
-        {{ property.name }}: {{ property.type }}{{ property.initDefaultValue }}{% ifnot forloop.last %},{% endif%}
+        {{ property.name }}: {{ property.type }} {{ property.initDefaultValue }}{% ifnot forloop.last %},{% endif%}
     {% endfor %}
     ) {
     {% for property in model.properties %}

--- a/templates/OperationHeaderSnippet.stencil
+++ b/templates/OperationHeaderSnippet.stencil
@@ -3,9 +3,3 @@ var headers = HTTPHeaders()
 {% for header in op.requiredHeaders %}
 headers["{{ header.key }}"] = {{ header.value }}
 {% endfor %}
-
-{% for header in op.optionalHeaders %}
-if let {{ header.paramName }} = options?.{{ header.paramName }} {
-    headers["{{ header.key }}"] = {{ header.value}}
-}
-{% endfor %}

--- a/templates/OperationOptionsSnippet.stencil
+++ b/templates/OperationOptionsSnippet.stencil
@@ -1,14 +1,14 @@
 // Process endpoint options
 if let options = options {
     // Query options
-    {% for param in op.optionalQueryParams %}
+    {% for param in op.params.query.optional %}
     if let {{ param.paramName }} = options.{{ param.paramName }} {
         queryParams.append("{{ param.key }}", {{ param.value}})
     }
     {% endfor %}
 
     // Header options
-    {% for header in op.optionalHeaders %}
+    {% for header in op.params.header.optional %}
     if let {{ header.paramName }} = options.{{ header.paramName }} {
         headers["{{ header.key }}"] = {{ header.value}}
     }

--- a/templates/OperationOptionsSnippet.stencil
+++ b/templates/OperationOptionsSnippet.stencil
@@ -1,14 +1,17 @@
 // Process endpoint options
 if let options = options {
     // Query options
-    {% for opt in op.options.queryOptions %}
-    if let {{ opt.name }} = options.{{ opt.name }} { queryParams.append("{{ opt.name }}", {{ opt.name}}) }
+    {% for param in op.optionalQueryParams %}
+    if let {{ param.paramName }} = options.{{ param.paramName }} {
+        queryParams.append("{{ param.key }}", {{ param.value}})
+    }
     {% endfor %}
 
     // Header options
-    {% for opt in op.options.headerOptions %}
-    if let {{ opt.name }} = options.{{ opt.name }} {
-        headers[.{{ opt.name }}] = {{ opt.name }}
+    {% for header in op.optionalHeaders %}
+    if let {{ header.paramName }} = options.{{ header.paramName }} {
+        headers["{{ header.key }}"] = {{ header.value}}
     }
     {% endfor %}
+
 }

--- a/templates/OperationQueryParamSnippet.stencil
+++ b/templates/OperationQueryParamSnippet.stencil
@@ -1,6 +1,6 @@
 // Construct query
 var queryParams: [QueryParameter] = [
-    {% for param in op.requiredQueryParams %}
+    {% for param in op.params.query.required %}
     ("{{ param.key }}" , {{ param.value}})
     {% endfor %}
 ]

--- a/templates/OperationQueryParamSnippet.stencil
+++ b/templates/OperationQueryParamSnippet.stencil
@@ -5,9 +5,4 @@ var queryParams: [QueryParameter] = [
     {% endfor %}
 ]
 
-{% for param in op.optionalQueryParams %}
-if let {{ param.paramName }} = options?.{{ param.paramName }} {
-    queryParams.append("{{ param.key }}", {{ param.value}})
-}
-{% endfor %}
 

--- a/templates/OperationUrlSnippet.stencil
+++ b/templates/OperationUrlSnippet.stencil
@@ -1,7 +1,7 @@
 // Construct URL
-let urlTemplate = "{{ op.request.uri }}{{ op.request.path }}"
-let pathParams = [
-    {% for param in op.uriParams %}
+let urlTemplate = "{{ op.request.path }}"
+let pathParams:[String: String] = [
+    {% for param in op.pathParams %}
         "{{ param.key }}" : {{ param.value}},
     {% endfor %}
 ]

--- a/templates/OperationUrlSnippet.stencil
+++ b/templates/OperationUrlSnippet.stencil
@@ -1,7 +1,7 @@
 // Construct URL
 let urlTemplate = "{{ op.request.path }}"
-let pathParams:[String: String] = [
-    {% for param in op.pathParams %}
+let pathParams = [
+    {% for param in op.params.path %}
         "{{ param.key }}" : {{ param.value}},
     {% endfor %}
 ]


### PR DESCRIPTION
* do not add request.uri in the url template. 
* remove unnecessary properties in RequestViewModel that are not used
* Pull 'ContentType' header from request parameter. 
* Refactor a function to generate the required, optionals query params and headers
* Move logic to build optional header /query params to the unwrapped options code block.