### PR TITLE
Add AzureCore dependency to generated Package.swift

### DIFF
--- a/templates/Package.stencil
+++ b/templates/Package.stencil
@@ -11,14 +11,19 @@ let package = Package(
         .macOS(.v10_15), .iOS(.v12), .tvOS(.v12)
     ],
     products: [
-        .library(name: "{{ model.name }}", targets: ["{{ model.name }}"])
+        .library(name: "{{ model.name }}", type: .static ,targets: ["{{ model.name }}"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(
+            url: "https://github.com/Azure/azure-sdk-for-ios.git",
+               .branch("master")
+        )
+    ],
     targets: [
         // Build targets
         .target(
             name: "{{ model.name }}",
-            dependencies: [],
+            dependencies: ["AzureCore"],
             path: "Sources"
         ),
         // TODO: Add test targets when test code is generated


### PR DESCRIPTION
* Add dependency with 'azure ios sdk' using github repo and master branch
* Add 'AzureCore' in target 

With this PR, we can run 'swift build' in the generated code and get a '.a' file for the library