### PR TITLE
Fix initializer doc comments.

### DIFF
--- a/src/AutorestSwift/View Models/ViewModelPrimitives.swift
+++ b/src/AutorestSwift/View Models/ViewModelPrimitives.swift
@@ -28,9 +28,12 @@ import Foundation
 
 /// formatted version of comment
 struct ViewModelComment: CustomStringConvertible {
+    let rawValue: String
+
     var description: String
 
     init(from descVal: String?) {
+        self.rawValue = descVal ?? ""
         self.description = ""
         guard let desc = descVal else { return }
         guard desc.trimmingCharacters(in: .whitespacesAndNewlines) != "" else { return }

--- a/templates/ClientMethodOptionsFile.stencil
+++ b/templates/ClientMethodOptionsFile.stencil
@@ -20,7 +20,7 @@ public struct {{ model.name }}: AzureOptions {
     /// Initialize a `{{ model.name }}` structure.
     /// - Parameters:
 {% for property in model.properties %}
-    ///   - {{ property.name }}: {{ property.comment }}
+    ///   - {{ property.name }}: {{ property.comment.rawValue }}
     ///   - clientRequestId: A client-generated, opaque value with 1KB character limit that is recorded in analytics logs.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
 {% endfor %}

--- a/templates/ModelFile.stencil
+++ b/templates/ModelFile.stencil
@@ -12,7 +12,7 @@ public {{ model.objectType }} {{ model.name }} : Codable {
     /// Initialize a `{{ model.name }}` structure.
     /// - Parameters:
     {% for property in model.properties %}
-    ///   - {{ property.name }}: {{ property.comment }}
+    ///   - {{ property.name }}: {{ property.comment.rawValue }}
     {% endfor %}
     public init(
     {% for property in model.properties %}


### PR DESCRIPTION
Fixes this:
```Swift
    /// Initialize a `SendReadReceiptOptions` structure.
    /// - Parameters:

    ///   - bad: /// bad comments!
    ///   - clientRequestId: A client-generated, opaque value with 1KB character limit that is recorded in analytics logs.
    ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.

```