### PR TITLE
Support PATCH , not JSON patch, if  content type is `application/json'

### DIFF
--- a/src/AutorestSwift/Models/Complex/Request.swift
+++ b/src/AutorestSwift/Models/Complex/Request.swift
@@ -50,4 +50,9 @@ class Request: Metadata {
         if signatureParameters != nil { try? container.encode(signatureParameters, forKey: .signatureParameters) }
         try super.encode(to: encoder)
     }
+
+    /// Lookup a parameter by name.
+    func parameter(for name: String) -> Parameter? {
+        return parameters?.first { $0.serializedName == name }
+    }
 }

--- a/src/AutorestSwift/View Models/RequestViewModel.swift
+++ b/src/AutorestSwift/View Models/RequestViewModel.swift
@@ -69,7 +69,13 @@ struct RequestViewModel {
 
         // Determine which kind of request body snippet to render
         if method == "patch" {
-            self.strategy = RequestBodyType.patchBody.rawValue
+            if let contentTypeParameter = request.parameter(for: "Content-Type"),
+                let constantSchema = contentTypeParameter.schema as? ConstantSchema,
+                constantSchema.value.value == "application/json" {
+                self.strategy = RequestBodyType.body.rawValue
+            } else {
+                self.strategy = RequestBodyType.patchBody.rawValue
+            }
         } else {
             self.strategy = bodyParam != nil ? RequestBodyType.body.rawValue : RequestBodyType.noBody.rawValue
         }


### PR DESCRIPTION
If the Request content type is `application/json' instead of 'application/json-patch-json', 
send PATCH instead of JSON PATCH.
For PATCH, se the HTTP request method to PATCH and serialize the payload in JSON format.