### PR TITLE
Use let instead of var when there is no optional params in query para…

### DIFF
--- a/src/AutorestSwift/View Models/OperationViewModel.swift
+++ b/src/AutorestSwift/View Models/OperationViewModel.swift
@@ -67,6 +67,8 @@ struct Params {
     var required: [KeyValueViewModel]
     // Query Params/Header need to add Nil check
     var optional: [KeyValueViewModel]
+    // Whether to 'var' or 'let' in generated code for the param declaration
+    var declaration: String = "var"
 
     init(from params: Params? = nil) {
         self.required = params?.required ?? [KeyValueViewModel]()
@@ -165,7 +167,6 @@ struct OperationViewModel {
         }
 
         // Construct the relevant view models
-
         if let bodyParam = operation.requests?.first?.bodyParam {
             let bodyParamName = operation.requests?.first?.bodyParamName(for: operation)
             self.bodyParam = ParameterViewModel(from: bodyParam, withName: bodyParamName)
@@ -190,6 +191,9 @@ struct OperationViewModel {
         // Add a blank key,value in order for Stencil generates an empty dictionary for QueryParams and PathParams constructor
         if params.query.required.count == 0 { params.query.required.append(KeyValueViewModel(key: "", value: "")) }
         if params.path.count == 0 { params.path.append(KeyValueViewModel(key: "", value: "\"\"")) }
+
+        params.query.declaration = params.query.optional.count == 0 ? "let" : "var"
+        params.header.declaration = params.header.optional.count == 0 ? "let" : "var"
 
         self.params = params
         self.pipelineContext = pipelineContext

--- a/templates/OperationHeaderSnippet.stencil
+++ b/templates/OperationHeaderSnippet.stencil
@@ -1,5 +1,5 @@
 // Construct headers
-var headers = HTTPHeaders()
+{{ op.params.header.declaration }} headers = HTTPHeaders()
 {% for header in op.params.header.required %}
 headers["{{ header.key }}"] = {{ header.value }}
 {% endfor %}

--- a/templates/OperationQueryParamSnippet.stencil
+++ b/templates/OperationQueryParamSnippet.stencil
@@ -1,5 +1,5 @@
 // Construct query
-var queryParams: [QueryParameter] = [
+{{ op.params.query.declaration }} queryParams: [QueryParameter] = [
     {% for param in op.params.query.required %}
     ("{{ param.key }}" , {{ param.value}})
     {% endfor %}


### PR DESCRIPTION
…ms and header.

With the change, the generated code compile with no warning.