### PR TITLE
Disable swiftlint rule in generated code

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,2 +1,5 @@
 disabled_rules: # rule identifiers to exclude from running
 - large_tuple
+- function_body_length
+
+excluded: # paths to ignore during linting.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,5 @@
 disabled_rules: # rule identifiers to exclude from running
 - large_tuple
 - function_body_length
-
-excluded: # paths to ignore during linting.
+- identifier_name
+- line_length

--- a/src/AutorestSwift/Code Generator/Manager.swift
+++ b/src/AutorestSwift/Code Generator/Manager.swift
@@ -69,7 +69,7 @@ class Manager {
         try generator.generate()
 
         // Run SwiftLint and SwiftFormat on generated files
-        try formatCode(atBaseUrl: packageUrl)
+        formatCode(atBaseUrl: packageUrl)
     }
 
     /// Decodes the YAML code model file into Swift objects and evaluates model consistency

--- a/templates/ClientMethodOptionsFile.stencil
+++ b/templates/ClientMethodOptionsFile.stencil
@@ -2,6 +2,10 @@
 
 {% include "ImportSnippet.stencil" %}
 
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+
 /// User-configurable options for the `{{ model.clientName }}.{{ model.operationName }}` operation.
 public struct {{ model.name }}: AzureOptions {
 

--- a/templates/ClientOptionsFile.stencil
+++ b/templates/ClientOptionsFile.stencil
@@ -1,6 +1,9 @@
 {% include "HeaderSnippet.stencil" %}
 
 {% include "ImportSnippet.stencil" %}
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 
 /// User-configurable options for the `{{ model.name }}`.
 public struct {{ model.name }}Options: AzureClientOptions {

--- a/templates/ModelFile.stencil
+++ b/templates/ModelFile.stencil
@@ -1,6 +1,10 @@
 {% include "HeaderSnippet.stencil" %}
 
 {% include "ImportSnippet.stencil" %}
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable cyclomatic_complexity
 
 {{ model.comment }}
 public {{ model.objectType }} {{ model.name }} : Codable {

--- a/templates/ServiceClientFile.stencil
+++ b/templates/ServiceClientFile.stencil
@@ -1,6 +1,11 @@
 {% include "HeaderSnippet.stencil" %}
 
 {% include "ImportSnippet.stencil" %}
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+// swiftlint:disable cyclomatic_complexity
+// swiftlint:disable function_body_length
+// swiftlint:disable type_body_length
 
 {{ model.comment }}
 public final class {{ model.name }}: PipelineClient {


### PR DESCRIPTION
With this PR, there should be no lint error in the generated code. Only in the dependency code.