### PR TITLE
Use Stencil smart trim behavior to remove excess empty lines in gener…

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,7 @@ target 'AutorestSwift' do
 
   # Pods for AutorestSwift
   pod 'Yams'
-  pod 'Stencil', '~> 0.13.1'
+  pod 'Stencil', :git => 'https://github.com/stencilproject/Stencil.git', :branch => 'trim_whitespace'
   pod 'SwiftFormat/CLI'
   pod 'SwiftLint'
 

--- a/src/AutorestSwift/Utils/StencilUtil.swift
+++ b/src/AutorestSwift/Utils/StencilUtil.swift
@@ -30,7 +30,7 @@ import Stencil
 
 public func renderTemplate(filename: String, dictionary: [String: Any]) throws -> String {
     let fsLoader = FileSystemLoader(bundle: [Bundle.main])
-    let environment = Environment(loader: fsLoader)
+    let environment = Environment(loader: fsLoader, trimBehavior: TrimBehavior.smart)
 
     return try environment.renderTemplate(name: filename, context: dictionary)
 }


### PR DESCRIPTION
…ated code.

Since the PR is not merged to master, we need to change Stencil dependency to the PR branch instead.

Per PR comment: 
smart Trim behavior means `It also comes with a built in .smart case that removes whitespace before a block, and whitespace and a single newline after a block.`