### PR TITLE
Pull swiftFormat swiftlint dependency in SPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,14 +26,17 @@ copyTestResources:
 	mkdir -p ${TEST_RESOURCES_DIRECTORY}
 	cp templates/* ${TEST_RESOURCES_DIRECTORY}
 
+buildSwiftlint:
+	scripts/build-swift-lint.sh
+
 copyTools:
-	pod install
-	cp ./Pods/SwiftFormat/CommandLineTool/swiftformat ${RUN_RESOURCES_DIRECTORY}
-	cp ./Pods/SwiftLint/swiftlint ${RUN_RESOURCES_DIRECTORY}
+	chmod +w ./.build/checkouts/SwiftFormat/CommandLineTool/swiftformat
+	cp ./.build/checkouts/SwiftFormat/CommandLineTool/swiftformat ${RUN_RESOURCES_DIRECTORY}
+	cp ./.build/checkouts/SwiftLint/.build/x86_64-apple-macosx/debug/swiftlint ${RUN_RESOURCES_DIRECTORY}
 	cp ./.swiftformat ${RUN_RESOURCES_DIRECTORY}
 	cp ./.swiftlint.yml ${RUN_RESOURCES_DIRECTORY}
 
-install: build copyTools
+install: build buildSwiftlint copyTools
 
 run: build
 	${EXECUTABLE_DIRECTORY}/AutorestSwift

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/stencilproject/Stencil.git", .branch("trim_whitespace")),
         .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.45.6"),
-        .package(url: "https://github.com/realm/SwiftLint.git", .branch("master"))
+    .package(url: "https://github.com/realm/SwiftLint.git", from: "0.40.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -10,9 +10,11 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/jpsim/Yams.git", from: "3.0.1"),
+        .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0"),
         .package(url: "https://github.com/stencilproject/Stencil.git", .branch("trim_whitespace")),
-        .package(url: "https://github.com/apple/swift-nio", from: "2.0.0")
+        .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.45.6"),
+        .package(url: "https://github.com/realm/SwiftLint.git", .branch("master"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/scripts/build-swift-lint.sh
+++ b/scripts/build-swift-lint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd ./.build/checkouts/SwiftLint/Source/swiftlint
+swift build
+
+cd ../../../../..


### PR DESCRIPTION
* Add swiftFormat and swiftlint dependency in Package.swift
* Add script to compile swiftlint after SPM pull the source of swiftlint in .build/checkouts/SwiftLint directory
* Update MakeFile 'make install' to remove 'pod install' so that we can build in WSL
