### PR TITLE
Create a tmp directory for each autorest code generation

### DIFF
--- a/src/AutorestSwift/Code Generator/Manager.swift
+++ b/src/AutorestSwift/Code Generator/Manager.swift
@@ -70,7 +70,9 @@ class Manager {
     init(withString string: String) {
         self.mode = .autorest
         self.inputString = Manager.sanitize(yaml: string)
+        // for autorest mode, create a temp directory using a random Guid as the directory name
         self.destinationRootUrl = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent(UUID().uuidString)
         self.packageUrl = nil
     }
 


### PR DESCRIPTION
so that stale obsolete  files from previous code generation will not get sent to Autoreset.
Fixes #165.