### PR TITLE
Revert to use cocopod to install swiftlint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,13 @@ buildSwiftlint:
 	scripts/build-swift-lint.sh
 
 copyTools:
-	chmod +w ./.build/checkouts/SwiftFormat/CommandLineTool/swiftformat
-	cp ./.build/checkouts/SwiftFormat/CommandLineTool/swiftformat ${RUN_RESOURCES_DIRECTORY}
-	cp ./.build/checkouts/SwiftLint/.build/x86_64-apple-macosx/debug/swiftlint ${RUN_RESOURCES_DIRECTORY}
+	pod install
+	cp ./Pods/SwiftFormat/CommandLineTool/swiftformat ${RUN_RESOURCES_DIRECTORY}
+	cp ./Pods/SwiftLint/swiftlint ${RUN_RESOURCES_DIRECTORY}
 	cp ./.swiftformat ${RUN_RESOURCES_DIRECTORY}
 	cp ./.swiftlint.yml ${RUN_RESOURCES_DIRECTORY}
 
-install: build buildSwiftlint copyTools
+install: build copyTools
 
 run: build
 	${EXECUTABLE_DIRECTORY}/AutorestSwift


### PR DESCRIPTION
make install becomes instable when we are building swiftlint from github.
Revert to use cocoapod to install swiftlint