### PR TITLE
Change script testserver_codegen.sh to make it revert to old stage wh…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 RUN_RESOURCES_DIRECTORY = ${EXECUTABLE_DIRECTORY}
 
 build: copyRunResources
-	swift build
+	swift build --target AutorestSwift
 
 copyRunResources:
 	mkdir -p ${RUN_RESOURCES_DIRECTORY}

--- a/scripts/testserver_codegen.sh
+++ b/scripts/testserver_codegen.sh
@@ -1,14 +1,41 @@
 #!/bin/bash
 
-make install
+echo "== Compile AutoRest Swift =="
+make install > /dev/null 2>&1
+
+if [ $? -eq 0 ]; then
+	echo "AutoRest Swift Compile succeed."
+else
+    echo "AutoRest Swift Compile failed! Exit."
+    exit
+fi
 
 files=( "head" "body-file" "report" "xms-error-responses")
 for i in "${files[@]}"
 do
-    rm ./test/integration/generated/$i/Package.resolved
-    rm -Rf ./test/integration/generated/$i/.build
-    autorest --input-file=./node_modules/@microsoft.azure/autorest.testserver/swagger/$i.json --output-folder=./test/integration/generated/$i --namespace=$i --use=.
+    echo "== Generate code for test server swagger $i.json =="
+    if [ "$1" = "--clean" ]
+    then
+	echo "Remove Package.resolved and .build directory."
+	rm ./test/integration/generated/$i/Package.resolved
+	rm -Rf ./test/integration/generated/$i/.build
+    fi
+    echo "autorest --input-file=./node_modules/@microsoft.azure/autorest.testserver/swagger/$i.json --output-folder=./test/integration/generated/$i --namespace=$i --use=."
+    autorest --input-file=./node_modules/@microsoft.azure/autorest.testserver/swagger/$i.json --output-folder=./test/integration/generated/$i --namespace=$i --use=. > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+	echo "autorest code generation succeed."
+    else
+	echo "autorest code generation failed. Revert the generated code."
+	git restore ./test/integration/generated/$i
+    fi
     cd ./test/integration/generated/$i
-    swift build
+    swift build  > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+	echo "swift build succeed."
     cd ../../../..
+    else
+	echo "swift build failed. Revert the generated code."
+    cd ../../../..
+	git restore ./test/integration/generated/$i
+    fi
 done


### PR DESCRIPTION
…en things failed

* only build AutorestSwift when make install
* change testserver_codegen.sh to check output of autorest and swift build, revert the generated code if failed
* To reduce noise from autorest and swift build, send the output to dev/null