### PR TITLE
Support UnixTime  test cases

### DIFF
--- a/AutorestSwift.xcodeproj/project.pbxproj
+++ b/AutorestSwift.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		0A22B45D24DB6FE900EC018E /* PatchUtilFile.stencil in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0A22B45C24DB6FD300EC018E /* PatchUtilFile.stencil */; };
 		0A22B46224DCE52000EC018E /* BodyParamSnippet.stencil in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0A22B46124DCE50400EC018E /* BodyParamSnippet.stencil */; };
 		0A22B46424E1E66F00EC018E /* JazzyFile.stencil in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0A22B46324E1E64900EC018E /* JazzyFile.stencil */; };
+		0A5F3F86251A65AD0079C1F0 /* BodyParamViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5F3F85251A65AD0079C1F0 /* BodyParamViewModel.swift */; };
 		0AA2BA1824EC866100CEA1D6 /* AutorestPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA2BA1724EC866100CEA1D6 /* AutorestPlugin.swift */; };
 		0AA2BA1B24EC951700CEA1D6 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA2BA1A24EC951700CEA1D6 /* Client.swift */; };
 		0AA2BA1D24EC956C00CEA1D6 /* CodableCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA2BA1C24EC956C00CEA1D6 /* CodableCodec.swift */; };
@@ -158,6 +159,8 @@
 		0AA2BA2524ED829600CEA1D6 /* Model+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA2BA2424ED829600CEA1D6 /* Model+Extensions.swift */; };
 		0AA2BA2924EDB4ED00CEA1D6 /* Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA2BA2824EDB4ED00CEA1D6 /* Common.swift */; };
 		0AA2BA2B24EDB87E00CEA1D6 /* ContentLengthHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA2BA2A24EDB87E00CEA1D6 /* ContentLengthHeader.swift */; };
+		0AA2BA2E24F4788600CEA1D6 /* VirtualParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA2BA2D24F4788500CEA1D6 /* VirtualParameter.swift */; };
+		0AA2BA3024F57A5B00CEA1D6 /* ParameterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA2BA2F24F57A5B00CEA1D6 /* ParameterType.swift */; };
 		F106826D24CF5B9C007EB4D5 /* .swiftlint.yml in CopyFiles */ = {isa = PBXBuildFile; fileRef = F106826C24CF5B7C007EB4D5 /* .swiftlint.yml */; };
 		F106826E24CF5B9C007EB4D5 /* .swiftformat in CopyFiles */ = {isa = PBXBuildFile; fileRef = F106826B24CF5B71007EB4D5 /* .swiftformat */; };
 		F106830424CF93C5007EB4D5 /* swiftformat in CopyFiles */ = {isa = PBXBuildFile; fileRef = F106830324CF9244007EB4D5 /* swiftformat */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -411,6 +414,7 @@
 		0A22B45C24DB6FD300EC018E /* PatchUtilFile.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = PatchUtilFile.stencil; sourceTree = "<group>"; };
 		0A22B46124DCE50400EC018E /* BodyParamSnippet.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = BodyParamSnippet.stencil; sourceTree = "<group>"; };
 		0A22B46324E1E64900EC018E /* JazzyFile.stencil */ = {isa = PBXFileReference; lastKnownFileType = text; path = JazzyFile.stencil; sourceTree = "<group>"; };
+		0A5F3F85251A65AD0079C1F0 /* BodyParamViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyParamViewModel.swift; sourceTree = "<group>"; };
 		0AA2B98824E5FD6500CEA1D6 /* package.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = package.json; sourceTree = "<group>"; };
 		0AA2BA1724EC866100CEA1D6 /* AutorestPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutorestPlugin.swift; sourceTree = "<group>"; };
 		0AA2BA1A24EC951700CEA1D6 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
@@ -421,6 +425,8 @@
 		0AA2BA2424ED829600CEA1D6 /* Model+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Model+Extensions.swift"; sourceTree = "<group>"; };
 		0AA2BA2824EDB4ED00CEA1D6 /* Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Common.swift; sourceTree = "<group>"; };
 		0AA2BA2A24EDB87E00CEA1D6 /* ContentLengthHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLengthHeader.swift; sourceTree = "<group>"; };
+		0AA2BA2D24F4788500CEA1D6 /* VirtualParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualParameter.swift; sourceTree = "<group>"; };
+		0AA2BA2F24F57A5B00CEA1D6 /* ParameterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParameterType.swift; sourceTree = "<group>"; };
 		50684F746D1F4406B5919571 /* Pods-AutorestSwiftTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutorestSwiftTests.debug.xcconfig"; path = "Target Support Files/Pods-AutorestSwiftTests/Pods-AutorestSwiftTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6111AB27AE90FF2215A75C1F /* libPods-AutorestSwiftTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AutorestSwiftTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		83D1551AC5FB9279DDE6D239 /* libPods-AutorestSwift.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AutorestSwift.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -481,7 +487,6 @@
 		OBJ_108 /* SerializationFormats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerializationFormats.swift; sourceTree = "<group>"; };
 		OBJ_109 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		OBJ_11 /* CodeGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeGenerator.swift; sourceTree = "<group>"; };
-		OBJ_118 /* tests */ = {isa = PBXFileReference; lastKnownFileType = folder; path = tests; sourceTree = SOURCE_ROOT; };
 		OBJ_120 /* scripts */ = {isa = PBXFileReference; lastKnownFileType = folder; path = scripts; sourceTree = SOURCE_ROOT; };
 		OBJ_122 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		OBJ_124 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -593,6 +598,7 @@
 		0A22B05A24CA4C9300EC018E /* View Models */ = {
 			isa = PBXGroup;
 			children = (
+				0A5F3F85251A65AD0079C1F0 /* BodyParamViewModel.swift */,
 				0A22B0C224D3301100EC018E /* ClientMethodOptionsViewModel.swift */,
 				0A22B0AC24D2198D00EC018E /* EnumerationChoiceViewModel.swift */,
 				0A22B05B24CA4CA400EC018E /* EnumerationFileViewModel.swift */,
@@ -846,6 +852,7 @@
 				OBJ_47 /* OperationGroup.swift */,
 				OBJ_48 /* OrSchema.swift */,
 				OBJ_49 /* Parameter.swift */,
+				0AA2BA2F24F57A5B00CEA1D6 /* ParameterType.swift */,
 				OBJ_50 /* PrimitiveSchema.swift */,
 				OBJ_51 /* Property.swift */,
 				OBJ_52 /* Protocol.swift */,
@@ -864,6 +871,7 @@
 				OBJ_65 /* UuidSchema.swift */,
 				OBJ_66 /* Value.swift */,
 				OBJ_67 /* ValueSchema.swift */,
+				0AA2BA2D24F4788500CEA1D6 /* VirtualParameter.swift */,
 				OBJ_68 /* XmlSerializationFormat.swift */,
 				OBJ_69 /* XorSchema.swift */,
 			);
@@ -880,7 +888,6 @@
 				OBJ_7 /* Sources */,
 				F1A6719324F5CCCC00C2712C /* AutorestSwiftTest */,
 				OBJ_114 /* Products */,
-				OBJ_118 /* tests */,
 				OBJ_120 /* scripts */,
 				0A22B06F24CB71E100EC018E /* templates */,
 				F106830224CF9226007EB4D5 /* tools */,
@@ -1226,6 +1233,7 @@
 				0A22B0F324D3671E00EC018E /* Manager.swift in Sources */,
 				0A22B0F424D3671E00EC018E /* SwiftGenerator.swift in Sources */,
 				0A22B0F524D3671E00EC018E /* AnySchema.swift in Sources */,
+				0A5F3F86251A65AD0079C1F0 /* BodyParamViewModel.swift in Sources */,
 				0A22B0F624D3671E00EC018E /* ArraySchema.swift in Sources */,
 				0A22B0F724D3671E00EC018E /* BinarySchema.swift in Sources */,
 				0A22B0F824D3671E00EC018E /* BooleanSchema.swift in Sources */,
@@ -1262,6 +1270,7 @@
 				0A22B11424D3671E00EC018E /* Parameter.swift in Sources */,
 				0A22B11524D3671E00EC018E /* PrimitiveSchema.swift in Sources */,
 				0A22B11624D3671E00EC018E /* Property.swift in Sources */,
+				0AA2BA3024F57A5B00CEA1D6 /* ParameterType.swift in Sources */,
 				0A22B11724D3671E00EC018E /* Protocol.swift in Sources */,
 				0A22B11824D3671E00EC018E /* Request.swift in Sources */,
 				0A22B11924D3671E00EC018E /* Response.swift in Sources */,
@@ -1321,6 +1330,7 @@
 				0A22B14A24D3671F00EC018E /* Schemas.swift in Sources */,
 				0A22B14B24D3671F00EC018E /* Security.swift in Sources */,
 				0A22B14C24D3671F00EC018E /* SecurityRequirement.swift in Sources */,
+				0AA2BA2E24F4788600CEA1D6 /* VirtualParameter.swift in Sources */,
 				0A22B14D24D3671F00EC018E /* SerializationFormats.swift in Sources */,
 				0A22B14E24D3671F00EC018E /* StencilUtil.swift in Sources */,
 				0A22B14F24D3671F00EC018E /* String+Extensions.swift in Sources */,
@@ -1503,7 +1513,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AutorestSwift.xcodeproj/AutorestSwift_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				OTHER_CFLAGS = "$(inherited)";
@@ -1532,7 +1542,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AutorestSwift.xcodeproj/AutorestSwift_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				OTHER_CFLAGS = "$(inherited)";

--- a/AutorestSwift.xcodeproj/project.pbxproj
+++ b/AutorestSwift.xcodeproj/project.pbxproj
@@ -474,6 +474,8 @@
 		F1A6719224F5CCCC00C2712C /* AutorestSwiftTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AutorestSwiftTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F1A6719624F5CCCC00C2712C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F1A671A924F5E54000C2712C /* AutoRestHeadTest.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AutoRestHeadTest.xcodeproj; path = test/integration/generated/head/AutoRestHeadTest.xcodeproj; sourceTree = SOURCE_ROOT; };
+		F1DE649E251304ED00B2C864 /* OperationResponseStatusCodeDeclareSnippet.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OperationResponseStatusCodeDeclareSnippet.stencil; sourceTree = "<group>"; };
+		F1DE649F251304FE00B2C864 /* OperationResponseUnixTImeBodySnippet.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OperationResponseUnixTImeBodySnippet.stencil; sourceTree = "<group>"; };
 		F4042B9C29C4EEFB3DCB9CE1 /* Pods-AutorestSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutorestSwift.debug.xcconfig"; path = "Target Support Files/Pods-AutorestSwift/Pods-AutorestSwift.debug.xcconfig"; sourceTree = "<group>"; };
 		OBJ_10 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		OBJ_100 /* Languages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Languages.swift; sourceTree = "<group>"; };
@@ -638,7 +640,6 @@
 				F1A5FD7C24DCFECB00A5CC6C /* ModelEncoderProperty.stencil */,
 				0A22B07324CB71E100EC018E /* ModelFile.stencil */,
 				F187186C250C2B3F00318867 /* OperationDefaultExceptionSnippet.stencil */,
-				F15151262512AA2D00DF0B9F /* OperationResponseExceptionSnippet.stencil */,
 				F151510525128E0B00DF0B9F /* OperationExceptionIntBodySnippet.stencil */,
 				F151510325128E0B00DF0B9F /* OperationExceptionJsonBodySnippet.stencil */,
 				F151510725128E0B00DF0B9F /* OperationExceptionSnippet.stencil */,
@@ -653,6 +654,7 @@
 				0A22B0C824D33F1000EC018E /* OperationResponseSnippet.stencil */,
 				0A22B0C524D3342300EC018E /* OperationResponseBodySnippet.stencil */,
 				F19B01C725073E7F00121831 /* OperationResponseDataSnippet.stencil */,
+				F15151262512AA2D00DF0B9F /* OperationResponseExceptionSnippet.stencil */,
 				F18717C7250B184A00318867 /* OperationResponseFailureBodySnippet.stencil */,
 				F18717D0250B184A00318867 /* OperationResponseFailureNoBodySnippet.stencil */,
 				F15150662511CA2E00DF0B9F /* OperationResponseIntBodySnippet.stencil */,
@@ -661,7 +663,9 @@
 				F15150D32512700D00DF0B9F /* OperationResponseNullableBodySnippet.stencil */,
 				0A22B0C424D333FF00EC018E /* OperationResponsePagedBodySnippet.stencil */,
 				F19B01D62507EA1300121831 /* OperationResponseStatusCodeSnippet.stencil */,
+				F1DE649E251304ED00B2C864 /* OperationResponseStatusCodeDeclareSnippet.stencil */,
 				F15150682511CA5600DF0B9F /* OperationResponseStringBodySnippet.stencil */,
+				F1DE649F251304FE00B2C864 /* OperationResponseUnixTImeBodySnippet.stencil */,
 				F1068F3D24D484C10082793F /* OperationSendRequestSnippet.stencil */,
 				0A22B09924D20BBA00EC018E /* OperationSnippet.stencil */,
 				F1068F4024D4B96B0082793F /* OperationUrlSnippet.stencil */,

--- a/AutorestSwiftTest/AutoRestBodyIntegerTest.swift
+++ b/AutorestSwiftTest/AutoRestBodyIntegerTest.swift
@@ -24,165 +24,186 @@
 //
 // --------------------------------------------------------------------------
 
-import XCTest
-import AzureCore
 import AutoRestIntegerTest
+import AzureCore
+import XCTest
 
 class AutoRestIntegerTest: XCTestCase {
     var client: AutoRestIntegerTestClient!
-    
+
     override func setUpWithError() throws {
         guard let baseUrl = URL(string: "http://localhost:3000") else {
             fatalError("Unable to form base URL")
         }
-        
-        client = try AutoRestIntegerTestClient(baseUrl: baseUrl,
-                                            authPolicy: AnonymousAccessPolicy(),
-                                            withOptions: AutoRestIntegerTestClientOptions())
+
+        client = try AutoRestIntegerTestClient(
+            baseUrl: baseUrl,
+            authPolicy: AnonymousAccessPolicy(),
+            withOptions: AutoRestIntegerTestClientOptions()
+        )
     }
 
     func test_BodyInteger_getNull200() throws {
         let expectation = XCTestExpectation(description: "Call getNull succeed")
         let failedExpectation = XCTestExpectation(description: "Call getNull failed")
         failedExpectation.isInverted = true
-        
-        client.getNull() { result, httpResponse  in
+
+        client.getNull { result, httpResponse in
             switch result {
-                case let .success(data):
-                    XCTAssertEqual(data, nil)
-                    XCTAssertEqual(httpResponse?.statusCode, 200)
-                    expectation.fulfill()
-               case let .failure(error):
-                    print("test failed. error=\(error.message)")
-                    failedExpectation.fulfill()
+            case let .success(data):
+                XCTAssertEqual(data, nil)
+                XCTAssertEqual(httpResponse?.statusCode, 200)
+                expectation.fulfill()
+            case let .failure(error):
+                print("test failed. error=\(error.message)")
+                failedExpectation.fulfill()
             }
         }
-        
+
         wait(for: [expectation], timeout: 15.0)
     }
- 
+
     func test_BodyInteger_getInvalid200() throws {
         let expectation = XCTestExpectation(description: "Call getInvalid succeed")
         let failedExpectation = XCTestExpectation(description: "Call getInvalid failed")
         failedExpectation.isInverted = true
-        
-        client.getInvalid() { result, httpResponse  in
+
+        client.getInvalid { result, httpResponse in
             switch result {
-                case .success:
+            case .success:
+                failedExpectation.fulfill()
+            case let .failure(error):
+                XCTAssertEqual(httpResponse?.statusCode, 200)
+                XCTAssert(error.message.contains("Decoding error."))
+                if let data = httpResponse?.data,
+                    let dataStr = String(data: data, encoding: .utf8) {
+                    XCTAssert(dataStr == "123jkl")
+                    expectation.fulfill()
+                } else {
                     failedExpectation.fulfill()
-                case let .failure(error):
-                    XCTAssertEqual(httpResponse?.statusCode, 200)
-                    XCTAssert(error.message.contains("Decoding error."))
-                    if let data = httpResponse?.data,
-                        let dataStr =  String(data: data, encoding: .utf8) {
-                        XCTAssert(dataStr == "123jkl")
-                         expectation.fulfill()
-                    } else {
-                        failedExpectation.fulfill()
-                    }
+                }
             }
         }
-        
+
         wait(for: [expectation], timeout: 15.0)
     }
-    
+
     func test_BodyInteger_getOverflowInt32_200() throws {
         let expectation = XCTestExpectation(description: "Call getOverflowInt32 succeed")
         let failedExpectation = XCTestExpectation(description: "Call getOverflowInt32 failed")
         failedExpectation.isInverted = true
-        
-        client.getOverflowInt32() { result, httpResponse  in
+
+        client.getOverflowInt32 { result, httpResponse in
             switch result {
-                case .success:
+            case .success:
+                failedExpectation.fulfill()
+            case let .failure(error):
+                XCTAssertEqual(httpResponse?.statusCode, 200)
+                XCTAssert(error.message.contains("Decoding error."))
+                if let data = httpResponse?.data,
+                    let dataStr = String(data: data, encoding: .utf8) {
+                    XCTAssert(dataStr == "2147483656")
+                    expectation.fulfill()
+                } else {
                     failedExpectation.fulfill()
-                case let .failure(error):
-                    XCTAssertEqual(httpResponse?.statusCode, 200)
-                    XCTAssert(error.message.contains("Decoding error."))
-                    if let data = httpResponse?.data,
-                        let dataStr =  String(data: data, encoding: .utf8) {
-                        XCTAssert(dataStr == "2147483656")
-                        expectation.fulfill()
-                    } else {
-                        failedExpectation.fulfill()
-                    }
+                }
             }
         }
-        
+
         wait(for: [expectation], timeout: 15.0)
     }
-    
+
     func test_BodyInteger_getUnderflowInt32_200() throws {
         let expectation = XCTestExpectation(description: "Call getOverflowInt32 succeed")
         let failedExpectation = XCTestExpectation(description: "Call getOverflowInt32 failed")
         failedExpectation.isInverted = true
-        
-        client.getUnderflowInt32() { result, httpResponse  in
+
+        client.getUnderflowInt32 { result, httpResponse in
             switch result {
-                case .success:
+            case .success:
+                failedExpectation.fulfill()
+            case let .failure(error):
+                XCTAssertEqual(httpResponse?.statusCode, 200)
+                XCTAssert(error.message.contains("Decoding error."))
+                if let data = httpResponse?.data,
+                    let dataStr = String(data: data, encoding: .utf8) {
+                    XCTAssert(dataStr == "-2147483656")
+                    expectation.fulfill()
+                } else {
                     failedExpectation.fulfill()
-                case let .failure(error):
-                    XCTAssertEqual(httpResponse?.statusCode, 200)
-                    XCTAssert(error.message.contains("Decoding error."))
-                    if let data = httpResponse?.data,
-                        let dataStr =  String(data: data, encoding: .utf8) {
-                        XCTAssert(dataStr == "-2147483656")
-                        expectation.fulfill()
-                    } else {
-                        failedExpectation.fulfill()
-                    }
+                }
             }
         }
-        
+
         wait(for: [expectation], timeout: 15.0)
     }
-    
+
     func test_BodyInteger_getOverflowInt64_200() throws {
         let expectation = XCTestExpectation(description: "Call getOverflowInt32 succeed")
         let failedExpectation = XCTestExpectation(description: "Call getOverflowInt32 failed")
         failedExpectation.isInverted = true
-        
-        client.getOverflowInt64() { result, httpResponse  in
+
+        client.getOverflowInt64 { result, httpResponse in
             switch result {
-                case .success:
+            case .success:
+                failedExpectation.fulfill()
+            case let .failure(error):
+                XCTAssertEqual(httpResponse?.statusCode, 200)
+                XCTAssert(error.message.contains("Decoding error."))
+                if let data = httpResponse?.data,
+                    let dataStr = String(data: data, encoding: .utf8) {
+                    XCTAssert(dataStr == "9223372036854775910")
+                    expectation.fulfill()
+                } else {
                     failedExpectation.fulfill()
-                case let .failure(error):
-                    XCTAssertEqual(httpResponse?.statusCode, 200)
-                    XCTAssert(error.message.contains("Decoding error."))
-                    if let data = httpResponse?.data,
-                        let dataStr =  String(data: data, encoding: .utf8) {
-                        XCTAssert(dataStr == "9223372036854775910")
-                        expectation.fulfill()
-                    } else {
-                        failedExpectation.fulfill()
-                    }
+                }
             }
         }
-        
+
         wait(for: [expectation], timeout: 15.0)
     }
-    
+
     func test_BodyInteger_getUnderflowInt64_200() throws {
         let expectation = XCTestExpectation(description: "Call getOverflowInt32 succeed")
         let failedExpectation = XCTestExpectation(description: "Call getOverflowInt32 failed")
         failedExpectation.isInverted = true
-        
-        client.getUnderflowInt64() { result, httpResponse  in
+
+        client.getUnderflowInt64 { result, httpResponse in
             switch result {
-                case .success:
+            case .success:
+                failedExpectation.fulfill()
+            case let .failure(error):
+                XCTAssertEqual(httpResponse?.statusCode, 200)
+                XCTAssert(error.message.contains("Decoding error."))
+                if let data = httpResponse?.data,
+                    let dataStr = String(data: data, encoding: .utf8) {
+                    XCTAssert(dataStr == "-9223372036854775910")
+                    expectation.fulfill()
+                } else {
                     failedExpectation.fulfill()
-                case let .failure(error):
-                    XCTAssertEqual(httpResponse?.statusCode, 200)
-                    XCTAssert(error.message.contains("Decoding error."))
-                    if let data = httpResponse?.data,
-                        let dataStr =  String(data: data, encoding: .utf8) {
-                        XCTAssert(dataStr == "-9223372036854775910")
-                        expectation.fulfill()
-                    } else {
-                        failedExpectation.fulfill()
-                    }
+                }
             }
         }
-        
         wait(for: [expectation], timeout: 15.0)
+    }
+
+    func test_BodyInteger_getUnixTime_200() throws {
+        let expectation = XCTestExpectation(description: "Call getOverflowInt32 succeed")
+        let failedExpectation = XCTestExpectation(description: "Call getOverflowInt32 failed")
+        failedExpectation.isInverted = true
+
+        client.getUnixTime { result, httpResponse in
+            switch result {
+                case let .success(data):
+                    XCTAssertEqual(httpResponse?.statusCode, 200)
+
+                    let expectedDate = ISO8601DateFormatter().date(from: "2016-04-13T00:00:00Z")
+                    XCTAssertEqual(expectedDate, data)
+                    expectation.fulfill()
+            case .failure:
+                failedExpectation.fulfill()
+            }
+        }
+             wait(for: [expectation], timeout: 15.0)
     }
 }

--- a/AutorestSwiftTest/AutoRestBodyIntegerTest.swift
+++ b/AutorestSwiftTest/AutoRestBodyIntegerTest.swift
@@ -60,7 +60,7 @@ class AutoRestIntegerTest: XCTestCase {
             }
         }
 
-        wait(for: [expectation], timeout: 15.0)
+        wait(for: [expectation], timeout: 5.0)
     }
 
     func test_BodyInteger_getInvalid200() throws {
@@ -85,7 +85,7 @@ class AutoRestIntegerTest: XCTestCase {
             }
         }
 
-        wait(for: [expectation], timeout: 15.0)
+        wait(for: [expectation], timeout: 5.0)
     }
 
     func test_BodyInteger_getOverflowInt32_200() throws {
@@ -110,7 +110,7 @@ class AutoRestIntegerTest: XCTestCase {
             }
         }
 
-        wait(for: [expectation], timeout: 15.0)
+        wait(for: [expectation], timeout: 5.0)
     }
 
     func test_BodyInteger_getUnderflowInt32_200() throws {
@@ -135,7 +135,7 @@ class AutoRestIntegerTest: XCTestCase {
             }
         }
 
-        wait(for: [expectation], timeout: 15.0)
+        wait(for: [expectation], timeout: 5.0)
     }
 
     func test_BodyInteger_getOverflowInt64_200() throws {
@@ -160,7 +160,7 @@ class AutoRestIntegerTest: XCTestCase {
             }
         }
 
-        wait(for: [expectation], timeout: 15.0)
+        wait(for: [expectation], timeout: 5.0)
     }
 
     func test_BodyInteger_getUnderflowInt64_200() throws {
@@ -184,12 +184,12 @@ class AutoRestIntegerTest: XCTestCase {
                 }
             }
         }
-        wait(for: [expectation], timeout: 15.0)
+        wait(for: [expectation], timeout: 5.0)
     }
 
     func test_BodyInteger_getUnixTime_200() throws {
-        let expectation = XCTestExpectation(description: "Call getOverflowInt32 succeed")
-        let failedExpectation = XCTestExpectation(description: "Call getOverflowInt32 failed")
+        let expectation = XCTestExpectation(description: "Call getUnixTime succeed")
+        let failedExpectation = XCTestExpectation(description: "Call getUnixTime failed")
         failedExpectation.isInverted = true
 
         client.getUnixTime { result, httpResponse in
@@ -204,6 +204,49 @@ class AutoRestIntegerTest: XCTestCase {
                 failedExpectation.fulfill()
             }
         }
-             wait(for: [expectation], timeout: 15.0)
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func test_BodyInteger_getInvalidUnixTime_200() throws {
+        let expectation = XCTestExpectation(description: "Call getInvalidUnixTime succeed")
+        let failedExpectation = XCTestExpectation(description: "Call getInvalidUnixTime failed")
+        failedExpectation.isInverted = true
+
+        client.getInvalidUnixTime { result, httpResponse in
+            switch result {
+            case .success:
+                failedExpectation.fulfill()
+            case let .failure(error):
+                XCTAssertEqual(httpResponse?.statusCode, 200)
+                XCTAssert(error.message.contains("Decoding error."))
+                if let data = httpResponse?.data,
+                    let dataStr = String(data: data, encoding: .utf8) {
+                    XCTAssert(dataStr == "123jkl")
+                    expectation.fulfill()
+                } else {
+                    failedExpectation.fulfill()
+                }
+            }
+        }
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func test_BodyInteger_getNullUnixTime_200() throws {
+        let expectation = XCTestExpectation(description: "Call getOverflowInt32 succeed")
+        let failedExpectation = XCTestExpectation(description: "Call getOverflowInt32 failed")
+        failedExpectation.isInverted = true
+
+        client.getNullUnixTime { result, httpResponse in
+            switch result {
+            case let .success(data):
+                XCTAssertEqual(data, nil)
+                XCTAssertEqual(httpResponse?.statusCode, 200)
+                expectation.fulfill()
+            case let .failure(error):
+                print("test failed. error=\(error.message)")
+                failedExpectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: 5.0)
     }
 }

--- a/AutorestSwiftTest/AutoRestSwaggerBatFileTest.swift
+++ b/AutorestSwiftTest/AutoRestSwaggerBatFileTest.swift
@@ -108,6 +108,6 @@ class AutoRestSwaggerBatFileTest: XCTestCase {
                }
            }
            
-           wait(for: [expectation], timeout: 10.0)
+           wait(for: [expectation], timeout: 30.0)
        }
 }

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ RUN_RESOURCES_DIRECTORY = ${EXECUTABLE_DIRECTORY}
 
 build: copyRunResources
 	swift build --target AutorestSwift
+	./scripts/swiftlint.sh
 
 copyRunResources:
 	mkdir -p ${RUN_RESOURCES_DIRECTORY}

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ modelerfour:
   flatten-models: true
 
   # this will flatten parameters when payload-flattening-threshold is specified (or marked in the input spec)
-  flatten-payloads: false
+  flatten-payloads: true
 
   # this will make the content-type parameter always specified
   always-create-content-type-parameter: true

--- a/src/AutorestSwift/Models/Complex/CodeModel.swift
+++ b/src/AutorestSwift/Models/Complex/CodeModel.swift
@@ -31,7 +31,7 @@ class CodeModel: Codable, LanguageShortcut {
     let info: Info
     let schemas: Schemas
     let operationGroups: [OperationGroup]
-    let globalParameters: [Parameter]?
+    let globalParameters: [ParameterType]?
     let security: Security
     var language: Languages
     let `protocol`: Protocols
@@ -43,12 +43,12 @@ class CodeModel: Codable, LanguageShortcut {
     }
 
     /// Lookup a global parameter by name.
-    func globalParameter(for name: String) -> Parameter? {
-        return globalParameters?.first { $0.name == name }
+    func globalParameter(for name: String) -> ParameterType? {
+        return globalParameters?.first(named: name)
     }
 
     func getApiVersion() -> String {
-        if let constantSchema = globalParameter(for: "apiVersion")?.schema as? ConstantSchema {
+        if let constantSchema = globalParameter(for: "api-version")?.schema as? ConstantSchema {
             return constantSchema.value.value
         } else {
             return ""

--- a/src/AutorestSwift/Models/Complex/Parameter.swift
+++ b/src/AutorestSwift/Models/Complex/Parameter.swift
@@ -27,7 +27,7 @@
 import Foundation
 
 /// A definition of an discrete input for an operation
-class Parameter: Value {
+class Parameter: Value, CustomDebugStringConvertible {
     /// suggested implementation location for this parameter
     let implementation: ImplementationLocation?
 
@@ -59,5 +59,19 @@ class Parameter: Value {
         if flattened != nil { try container.encode(flattened, forKey: .flattened) }
 
         try super.encode(to: encoder)
+    }
+
+    // MARK: CustomDebugStringConvertible
+
+    public var debugDescription: String {
+        return debugString() ?? description
+    }
+}
+
+extension Parameter: Equatable {
+    static func == (lhs: Parameter, rhs: Parameter) -> Bool {
+        // TODO: Improve this? This is technically the same assumption being
+        // made when using a dictionary.
+        return lhs.name == rhs.name
     }
 }

--- a/src/AutorestSwift/Models/Complex/ParameterType.swift
+++ b/src/AutorestSwift/Models/Complex/ParameterType.swift
@@ -1,0 +1,220 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+enum ParameterType: Codable {
+    case regular(Parameter)
+    case virtual(VirtualParameter)
+
+    // MARK: Codable
+
+    init(from decoder: Decoder) throws {
+        if let decoded = try? VirtualParameter(from: decoder) {
+            self = .virtual(decoded)
+        } else if let decoded = try? Parameter(from: decoder) {
+            self = .regular(decoded)
+        } else {
+            fatalError("Unable to decode ParameterType")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        switch self {
+        case let .regular(param):
+            try param.encode(to: encoder)
+        case let .virtual(param):
+            try param.encode(to: encoder)
+        }
+    }
+
+    // MARK: Property Helpers
+
+    var name: String {
+        return common.name
+    }
+
+    var schema: Schema {
+        return common.schema
+    }
+
+    var value: Value {
+        return common as Value
+    }
+
+    var required: Bool {
+        return common.required
+    }
+
+    var description: String {
+        return common.description
+    }
+
+    var serializedName: String? {
+        return common.serializedName
+    }
+
+    var `protocol`: Protocols {
+        return common.protocol
+    }
+
+    var implementation: ImplementationLocation? {
+        return common.implementation
+    }
+
+    var clientDefaultValue: String? {
+        return common.clientDefaultValue
+    }
+
+    var flattened: Bool {
+        return common.flattened ?? false
+    }
+
+    /// Return the common base class Parameter properties
+    private var common: Parameter {
+        switch self {
+        case let .regular(reg):
+            return reg
+        case let .virtual(virt):
+            return virt as Parameter
+        }
+    }
+
+    // MARK: Methods
+
+    /// Returns whether the given parameter is located in the specified location.
+    internal func located(in location: ParameterLocation) -> Bool {
+        if let httpParam = self.protocol.http as? HttpParameter {
+            return httpParam.in == location
+        } else {
+            return false
+        }
+    }
+
+    /// Returns whether the given parameter is located in any of the specified locations.
+    internal func located(in locations: [ParameterLocation]) -> Bool {
+        for location in locations {
+            if located(in: location) {
+                return true
+            }
+        }
+        return false
+    }
+}
+
+extension ParameterType: Equatable {
+    static func == (lhs: ParameterType, rhs: ParameterType) -> Bool {
+        switch lhs {
+        case let .regular(lparam):
+            if case let ParameterType.regular(rparam) = rhs {
+                return lparam == rparam
+            }
+        case let .virtual(lparam):
+            if case let ParameterType.virtual(rparam) = rhs {
+                return lparam == rparam
+            }
+        }
+        return false
+    }
+}
+
+extension Array where Element == ParameterType {
+    func first(named: String) -> Element? {
+        for param in self {
+            let name = param.serializedName ?? param.name
+            if named == name {
+                return param
+            }
+        }
+        // no match found
+        return nil
+    }
+
+    /// Returns the subset of `ParameterType` that are `VirtualParameter` types.
+    var virtual: [VirtualParameter] {
+        return compactMap { param in
+            if case let ParameterType.virtual(virtParam) = param {
+                return virtParam
+            }
+            return nil
+        }
+    }
+
+    /// Returns the required items that should be in the method signature
+    var inSignature: [ParameterType] {
+        return filter { param in
+            guard param.implementation == ImplementationLocation.method,
+                param.schema.type != .constant
+            else { return false }
+            // We track body params in a special way, so always omit them generally from the signature.
+            // If they belong in the signature, they will be added in a way to ensure they come first.
+            if let httpParam = param.protocol.http as? HttpParameter {
+                guard httpParam.in != .body else { return false }
+            }
+            return param.required
+        }
+    }
+
+    /// Returns the optional items that should be in the method's Options object
+    var inOptions: [ParameterType] {
+        return filter { param in
+            guard param.implementation == ImplementationLocation.method,
+                param.schema.type != .constant,
+                param.flattened == false
+            else { return false }
+            return !param.required
+        }
+    }
+
+    var inQuery: [ParameterType] {
+        return filter { param in
+            guard param.implementation == ImplementationLocation.method,
+                param.schema.type != .constant
+            else { return false }
+            return param.located(in: .query)
+        }
+    }
+
+    /// Returns the items that should be passed in the request header
+    var inHeader: [ParameterType] {
+        return filter { param in
+            guard param.implementation == ImplementationLocation.method,
+                param.schema.type != .constant
+            else { return false }
+            return param.located(in: .header)
+        }
+    }
+
+    /// Returns the items that should be passed in the path
+    var inPath: [ParameterType] {
+        return filter { param in
+            guard param.implementation == ImplementationLocation.method,
+                param.schema.type != .constant
+            else { return false }
+            return param.located(in: .path)
+        }
+    }
+}

--- a/src/AutorestSwift/Models/Complex/VirtualParameter.swift
+++ b/src/AutorestSwift/Models/Complex/VirtualParameter.swift
@@ -26,22 +26,39 @@
 
 import Foundation
 
-class GroupProperty: Property {
-    let originalParameter: [ParameterType]
+/// A definition of an discrete input for an operation
+class VirtualParameter: Parameter {
+    /// the original body parameter that this parameter is in effect replacing
+    let originalParameter: Parameter
+
+    /// if this parameter is for a nested property, this is the path of properties it takes to get there
+    let pathToProperty: [Property]
+
+    /// the target property this virtual parameter represents
+    let targetProperty: Property
+
+    // MARK: Codable
 
     enum CodingKeys: String, CodingKey {
-        case originalParameter
+        case originalParameter, pathToProperty, targetProperty
     }
 
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        originalParameter = try container.decode([ParameterType].self, forKey: .originalParameter)
+
+        originalParameter = try container.decode(Parameter.self, forKey: .originalParameter)
+        pathToProperty = try container.decode([Property].self, forKey: .pathToProperty)
+        targetProperty = try container.decode(Property.self, forKey: .targetProperty)
+
         try super.init(from: decoder)
     }
 
     override public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(originalParameter, forKey: .originalParameter)
+        try container.encode(pathToProperty, forKey: .pathToProperty)
+        try container.encode(targetProperty, forKey: .targetProperty)
+
         try super.encode(to: encoder)
     }
 }

--- a/src/AutorestSwift/Utils/Encodable+Extensions.swift
+++ b/src/AutorestSwift/Utils/Encodable+Extensions.swift
@@ -36,4 +36,15 @@ extension Encodable {
             }
         }
     }
+
+    func debugString() -> String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        if let jsonData = try? encoder.encode(self) {
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                return jsonString
+            }
+        }
+        return nil
+    }
 }

--- a/src/AutorestSwift/View Models/BodyParamViewModel.swift
+++ b/src/AutorestSwift/View Models/BodyParamViewModel.swift
@@ -26,22 +26,17 @@
 
 import Foundation
 
-class GroupProperty: Property {
-    let originalParameter: [ParameterType]
+/// View Model for the body param.
+struct BodyParamViewModel {
+    let name: String
+    let type: String
+    let flattened: Bool
+    let properties: [ParameterViewModel]
 
-    enum CodingKeys: String, CodingKey {
-        case originalParameter
-    }
-
-    public required init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        originalParameter = try container.decode([ParameterType].self, forKey: .originalParameter)
-        try super.init(from: decoder)
-    }
-
-    override public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(originalParameter, forKey: .originalParameter)
-        try super.encode(to: encoder)
+    init(from parameter: ParameterType, with operation: Operation) {
+        self.name = operation.request?.bodyParamName(for: operation) ?? parameter.name
+        self.type = parameter.schema.name
+        self.flattened = parameter.flattened
+        self.properties = [ParameterViewModel]()
     }
 }

--- a/src/AutorestSwift/View Models/ClientMethodOptionsViewModel.swift
+++ b/src/AutorestSwift/View Models/ClientMethodOptionsViewModel.swift
@@ -40,13 +40,13 @@ struct ClientMethodOptionsViewModel {
     // The list of properites for the options object
     let properties: [PropertyViewModel]
 
-    init(from operation: Operation, with model: CodeModel, parameters: [Parameter]) {
+    init(from operation: Operation, with model: CodeModel, parameters: [ParameterType]) {
         self.clientName = model.name
         self.operationName = operation.name
         self.name = "\(operation.name)Options"
         var properties = [PropertyViewModel]()
         parameters.forEach {
-            properties.append(PropertyViewModel(from: $0))
+            properties.append(PropertyViewModel(from: $0.value))
         }
         self.properties = properties
     }

--- a/src/AutorestSwift/View Models/ExceptionResponseViewModel.swift
+++ b/src/AutorestSwift/View Models/ExceptionResponseViewModel.swift
@@ -46,8 +46,9 @@ struct ExceptionResponseViewModel {
         let schemaResponse = response as? SchemaResponse
         self.description = schemaResponse?.description
 
-        if let objectType = schemaResponse?.schema.swiftType(optional: false) {
-            self.strategy = ResponseBodyType.strategy(for: objectType).rawValue
+        if let objectType = schemaResponse?.schema.swiftType(optional: false),
+            let type = schemaResponse?.schema.type {
+            self.strategy = ResponseBodyType.strategy(for: objectType, and: type).rawValue
             self.objectType = objectType
         } else {
             self.strategy = ResponseBodyType.noBody.rawValue

--- a/src/AutorestSwift/View Models/KeyValueViewModel.swift
+++ b/src/AutorestSwift/View Models/KeyValueViewModel.swift
@@ -48,7 +48,7 @@ struct KeyValueViewModel {
                     the value of the VM will be the name of the signature parameter.
         - Parameter operation: the operation which this paramter exists.
      */
-    init(from param: Parameter, with operation: Operation) {
+    init(from param: ParameterType, with operation: Operation) {
         self.key = param.serializedName ?? param.name
 
         if let constantSchema = param.schema as? ConstantSchema {

--- a/src/AutorestSwift/View Models/OperationViewModel.swift
+++ b/src/AutorestSwift/View Models/OperationViewModel.swift
@@ -30,19 +30,17 @@ struct OperationParameters {
     var header: Params
     var query: Params
     var path: [KeyValueViewModel]
-    var hasOptionalsParams: Bool = false
+    var body: BodyParams?
+    var signature: [ParameterViewModel]
+
+    var hasOptionalParams: Bool
 
     /// Build a list of required and optional query params and headers from a list of parameters
-    init(
-        parameters: [Parameter]?,
-        operation: Operation,
-        operationParameters: OperationParameters? = nil
-    ) {
-        self.header = operationParameters?.header ?? Params()
-        self.query = operationParameters?.query ?? Params()
-        self.path = operationParameters?.path ?? [KeyValueViewModel]()
-
-        for param in parameters ?? [] {
+    init(parameters: [ParameterType], operation: Operation) {
+        var header = Params()
+        var query = Params()
+        var path = [KeyValueViewModel]()
+        for param in parameters {
             guard let httpParam = param.protocol.http as? HttpParameter else { continue }
 
             let viewModel = KeyValueViewModel(from: param, with: operation)
@@ -60,6 +58,45 @@ struct OperationParameters {
                 continue
             }
         }
+
+        // Add a blank key,value in order for Stencil generates an empty dictionary for QueryParams and PathParams constructor
+        if query.required.isEmpty {
+            query.required.append(KeyValueViewModel(key: "", value: "\"\""))
+        }
+        if path.isEmpty {
+            path.append(KeyValueViewModel(key: "", value: "\"\""))
+        }
+
+        // If there is no optional query params, change query param declaration to 'let'
+        // For header, the declaration is 'let' when both required and optional headers are empty, since the required
+        // header parameters will be initialized out of header initializer
+        query.declaration = query.optional.isEmpty ? "let" : "var"
+        header.declaration = header.isEmpty ? "let" : "var"
+
+        // Set the body param, if applicable
+        if let bodyParam = operation.request?.bodyParam {
+            let bodyParamName = operation.request?.bodyParamName(for: operation)
+            let virtualParams = parameters.virtual
+
+            self.body = BodyParams(
+                param: ParameterViewModel(from: bodyParam, withName: bodyParamName),
+                strategy: bodyParam.flattened ? .flattened : .plain,
+                children: virtualParams.map { VirtualParam(from: $0) }
+            )
+        } else {
+            self.body = nil
+        }
+
+        var signaturePropertyViewModel = [ParameterViewModel]()
+        for param in parameters.inSignature {
+            signaturePropertyViewModel.append(ParameterViewModel(from: param))
+        }
+        self.signature = signaturePropertyViewModel
+
+        self.header = header
+        self.query = query
+        self.path = path
+        self.hasOptionalParams = !(query.optional.isEmpty && header.optional.isEmpty)
     }
 }
 
@@ -75,6 +112,43 @@ struct Params {
         self.required = params?.required ?? [KeyValueViewModel]()
         self.optional = params?.optional ?? [KeyValueViewModel]()
     }
+
+    var isEmpty: Bool {
+        return required.isEmpty && optional.isEmpty
+    }
+}
+
+enum BodyParamStrategy: String {
+    case plain
+    case flattened
+}
+
+struct BodyParams {
+    var param: ParameterViewModel
+    var strategy: String
+    var children: [VirtualParam]
+
+    init(param: ParameterViewModel, strategy: BodyParamStrategy, children: [VirtualParam]) {
+        self.param = param
+        self.strategy = strategy.rawValue
+        self.children = children
+        // Suppress comma on final child
+        if !children.isEmpty {
+            self.children[children.count - 1].separator = ""
+        }
+    }
+}
+
+struct VirtualParam {
+    var name: String
+    var path: String
+    var separator: String
+
+    init(from param: VirtualParameter) {
+        self.name = param.name
+        self.path = param.required ? param.name : "options?.\(param.name)"
+        self.separator = ","
+    }
 }
 
 /// View Model for an operation.
@@ -82,65 +156,44 @@ struct Params {
 ///     // a simple endpoint
 ///     public func simpleEndpoint(param: String? = nil, completionHandler: @escaping HTTPResultHandler<ReturnType>) { ... }
 struct OperationViewModel {
+    /// Name of the operation
     let name: String
+
+    /// Comment association with the operation
     let comment: ViewModelComment
+
     let signatureComment: ViewModelComment
-    let bodyParam: ParameterViewModel?
-    let signatureParams: [ParameterViewModel]
-    let returnType: ReturnTypeViewModel?
+
     let params: OperationParameters
+
+    let returnType: ReturnTypeViewModel?
+
+    let clientMethodOptions: ClientMethodOptionsViewModel
+
     let pipelineContext: [KeyValueViewModel]?
+
+    let request: RequestViewModel
     let responses: [ResponseViewModel]?
     let exceptions: [ExceptionResponseViewModel]?
-    let request: RequestViewModel?
-    let clientMethodOptions: ClientMethodOptionsViewModel
+
     let defaultException: ExceptionResponseViewModel?
     let defaultExceptionHasBody: Bool
 
     init(from operation: Operation, with model: CodeModel) {
+        guard let request = operation.request else { fatalError("Request not found for operation \(operation.name).") }
+        self.request = RequestViewModel(from: request, with: operation)
+
         self.name = operationName(for: operation)
         self.comment = ViewModelComment(from: operation.description)
 
-        var pipelineContext = [KeyValueViewModel]()
+        let params = operation.allParams
 
-        var params = OperationParameters(
-            parameters: operation.parameters,
-            operation: operation
-        )
-
-        var signatureParams = filterParams(for: operation.signatureParameters, with: [.path, .uri])
-        var optionsParams = filterParams(for: operation.signatureParameters, with: [.header, .query])
-
-        var requests = [RequestViewModel]()
         var responses = [ResponseViewModel]()
-        var exceptions = [ExceptionResponseViewModel]()
-
-        assert(
-            operation.requests?.count ?? 0 <= 1,
-            "Multiple requests per operation is currently not supported... \(operation.name)"
-        )
-        guard let request = operation.requests?.first else { fatalError("No requests found.") }
-        requests.append(RequestViewModel(from: request, with: operation))
-
-        let requestSignatureParams = filterParams(for: request.signatureParameters, with: [.path, .uri])
-        let requestOptionsParams = filterParams(
-            for: request.signatureParameters,
-            with: [.header, .query]
-        )
-
-        optionsParams.append(contentsOf: requestOptionsParams)
-        signatureParams.append(contentsOf: requestSignatureParams)
-
-        params = OperationParameters(
-            parameters: request.parameters,
-            operation: operation,
-            operationParameters: params
-        )
-
         for response in operation.responses ?? [] {
             responses.append(ResponseViewModel(from: response, with: operation))
         }
 
+        var exceptions = [ExceptionResponseViewModel]()
         var defaultException: ExceptionResponseViewModel?
         for exception in operation.exceptions ?? [] {
             let viewModel = ExceptionResponseViewModel(from: exception)
@@ -151,83 +204,52 @@ struct OperationViewModel {
             }
         }
 
+        // Build up allowable status codes that can be returned from the service.
         var statusCodes = [String]()
         for response in responses {
-            statusCodes.append(contentsOf: response.statusCodes)
+            statusCodes += response.statusCodes
         }
         for exception in exceptions {
-            statusCodes.append(contentsOf: exception.statusCodes)
+            statusCodes += exception.statusCodes
         }
 
+        // Configure PipelineContext
+        var pipelineContext = [KeyValueViewModel]()
         pipelineContext.append(KeyValueViewModel(
             key: "ContextKey.allowedStatusCodes.rawValue",
             value: "[\(statusCodes.joined(separator: ","))]"
         ))
+        self.pipelineContext = pipelineContext
 
         self.responses = responses
         self.exceptions = exceptions
         self.defaultException = defaultException
         self.defaultExceptionHasBody = (defaultException != nil) && defaultException?.objectType != "Void"
 
-        // current logic only supports a single request and response
-        assert(requests.count <= 1, "Multiple requests per operation is currently not supported... \(operation.name)")
-
-        self.request = requests.first
-
-        // Construct the relevant view models
-        if let bodyParam = operation.requests?.first?.bodyParam {
-            let bodyParamName = operation.requests?.first?.bodyParamName(for: operation)
-            self.bodyParam = ParameterViewModel(from: bodyParam, withName: bodyParamName)
-        } else {
-            self.bodyParam = nil
-        }
-
-        var signaturePropertyViewModel = [ParameterViewModel]()
-        signatureParams.forEach {
-            signaturePropertyViewModel.append(ParameterViewModel(from: $0))
-        }
-
         self.returnType = ReturnTypeViewModel(from: self.responses)
 
+        // create help struct to manage required and optional params in
+        // headers/query/path, etc.
+        self.params = OperationParameters(parameters: params, operation: operation)
+
         var signatureComments: [String] = []
-        if let param = bodyParam {
+        if let param = self.params.body?.param {
             signatureComments.append("   - \(param.name) : \(param.comment.withoutPrefix)")
         }
-        for param in signatureParams where param.description != "" {
+        for param in params.inSignature where param.description != "" {
             signatureComments.append("   - \(param.name) : \(param.description)")
         }
         self.signatureComment = ViewModelComment(from: signatureComments.joined(separator: "\n"))
-        self.signatureParams = signaturePropertyViewModel
-
-        // Add a blank key,value in order for Stencil generates an empty dictionary for QueryParams and PathParams constructor
-        if params.query.required.count == 0 { params.query.required.append(KeyValueViewModel(key: "", value: "\"\"")) }
-        if params.path.count == 0 { params.path.append(KeyValueViewModel(key: "", value: "\"\"")) }
-
-        // If there is no optional query params, change query param declaration to 'let'
-        // For header, the declaration is 'let' when both required and optional headers are empty, since the required
-        // header parameters will be initialized out of header initializer
-        params.query.declaration = params.query.optional.count == 0 ? "let" : "var"
-        params.header.declaration = params.header.optional.count == 0 && params.header.required
-            .count == 0 ? "let" : "var"
-        params.hasOptionalsParams = params.query.optional.count + params.header.optional.count > 0
-
-        self.params = params
-        self.pipelineContext = pipelineContext
 
         self.clientMethodOptions = ClientMethodOptionsViewModel(
             from: operation,
             with: model,
-            parameters: optionsParams
+            parameters: params.inOptions
         )
-
-        // validate our assumption that there won't be any "required options"
-        for param in optionsParams {
-            assert(param.required == false, "Unexpectedly found a required 'option'... \(param.name)")
-        }
     }
 }
 
-private func filterParams(for params: [Parameter]?, with allowed: [ParameterLocation]) -> [Parameter] {
+private func filterParams(for params: [ParameterType]?, with allowed: [ParameterLocation]) -> [ParameterType] {
     let optionsParams = params?.filter { param in
         if let httpParam = param.protocol.http as? HttpParameter {
             return allowed.contains(httpParam.in)
@@ -259,11 +281,11 @@ private func operationName(for operation: Operation) -> String {
     }
     operationName = nameComps.joined()
 
-    // Strip off the body param name, if there is one.
+    // Strip off the body param name, if there is one and the parameter is not flattened.
     // (ex: `createCat(...)` becomes `create(cat:...)`
-    if let bodyParamName = operation.requests?.first?.bodyParamName(for: operation) {
+    if let bodyParamName = operation.request?.bodyParamName(for: operation) {
         let suffix = bodyParamName.prefix(1).uppercased() + bodyParamName.dropFirst()
-        if operationName.hasSuffix(suffix) {
+        if operationName.hasSuffix(suffix), !(operation.request?.bodyParam?.flattened ?? false) {
             operationName = String(operationName.dropLast(suffix.count))
         }
     }

--- a/src/AutorestSwift/View Models/ParameterViewModel.swift
+++ b/src/AutorestSwift/View Models/ParameterViewModel.swift
@@ -36,7 +36,7 @@ struct ParameterViewModel {
     let defaultValue: ViewModelDefault
     let comment: ViewModelComment
 
-    init(from param: Parameter, withName name: String? = nil) {
+    init(from param: ParameterType, withName name: String? = nil) {
         self.name = name ?? param.name
         self.optional = !param.required
         self.type = param.schema.swiftType(optional: optional)

--- a/src/AutorestSwift/View Models/RequestViewModel.swift
+++ b/src/AutorestSwift/View Models/RequestViewModel.swift
@@ -35,23 +35,11 @@ enum RequestBodyType: String {
     case patchBody
 }
 
-struct BodyParam {
-    let name: String
-    let type: String
-    let propertyNames: [String]
-
-    init(from parameter: Parameter, with operation: Operation) {
-        self.name = operation.requests?.first?.bodyParamName(for: operation) ?? parameter.name
-        self.type = parameter.schema.name
-        self.propertyNames = (parameter.schema.properties ?? []).map { $0.name }
-    }
-}
-
 /// View Model for the method request creation.
 struct RequestViewModel {
     let path: String
     let method: String
-    let bodyParam: BodyParam?
+    let bodyParam: BodyParamViewModel?
     /// Identifies the correct snippet to use when rendering the view model
     let strategy: String
 
@@ -63,7 +51,7 @@ struct RequestViewModel {
 
         // create a body param model, if the request has one
         if let bodyParam = request.bodyParam {
-            self.bodyParam = BodyParam(from: bodyParam, with: operation)
+            self.bodyParam = BodyParamViewModel(from: bodyParam, with: operation)
         } else {
             self.bodyParam = nil
         }

--- a/src/AutorestSwift/View Models/ResponseViewModel.swift
+++ b/src/AutorestSwift/View Models/ResponseViewModel.swift
@@ -37,12 +37,16 @@ enum ResponseBodyType: String {
     case intBody
     /// Service returns a JSON body
     case jsonBody
+    /// Service returns a unixTime body
+    case unixTimeBody
 
-    static func strategy(for input: String) -> ResponseBodyType {
+    static func strategy(for input: String, and type: AllSchemaTypes) -> ResponseBodyType {
         if input == "String" {
             return .stringBody
         } else if input.starts(with: "Int") {
             return .intBody
+        } else if input == "Date", type == .unixTime {
+            return .unixTimeBody
         } else {
             return .jsonBody
         }
@@ -87,8 +91,9 @@ struct ResponseViewModel {
         } else {
             self.pagingNames = nil
             self.pagedElementClassName = nil
-            if let objectType = schemaResponse?.schema.swiftType(optional: false) {
-                self.strategy = ResponseBodyType.strategy(for: objectType).rawValue
+            if let objectType = schemaResponse?.schema.swiftType(optional: false),
+                let type = schemaResponse?.schema.type {
+                self.strategy = ResponseBodyType.strategy(for: objectType, and: type).rawValue
                 self.objectType = objectType
             } else {
                 self.strategy = ResponseBodyType.noBody.rawValue

--- a/templates/BodyParamSnippet.stencil
+++ b/templates/BodyParamSnippet.stencil
@@ -1,3 +1,3 @@
-{% if op.bodyParam != nil %}
-{{ op.bodyParam.name }}: {{ op.bodyParam.type }}{{ op.bodyParam.defaultValue }},
+{% if op.params.body.strategy == "plain" %}
+{{ op.params.body.param.name }}: {{ op.params.body.param.type }}{{ op.params.body.param.defaultValue }},
 {% endif %}

--- a/templates/OperationRequestBodySnippet.stencil
+++ b/templates/OperationRequestBodySnippet.stencil
@@ -1,15 +1,27 @@
 // Construct request
-guard let requestBody = try? JSONEncoder().encode( {{ op.request.bodyParam.name }} ) else {
+{% if op.params.body.strategy == "plain" %}
+guard let requestBody = try? JSONEncoder().encode( {{ op.params.body.param.name }} ) else {
     self.options.logger.error("Failed to encode request body as json.")
     return
 }
-
+{% elif op.params.body.strategy == "flattened" %}
+let body = {{ op.params.body.param.type }}(
+    {% for child in op.params.body.children %}
+    {{ child.name }}: {{ child.path }}{{ child.separator }}
+    {% endfor %}
+)
+guard let requestBody = try? JSONEncoder().encode(body) else {
+    self.options.logger.error("Failed to encode request body as json.")
+    return
+}
+{% endif %}
 guard let requestUrl = url.appendingQueryParameters(queryParams) else {
-    self.options.logger.error("Failed to append query parameters to url")
+    self.options.logger.error("Failed to append query parameters to URL")
     return
 }
 
 guard let request = try? HTTPRequest(method: .{{ op.request.method }}, url: requestUrl, headers: headers, data: requestBody) else {
-    self.options.logger.error("Failed to construct Http request")
+    self.options.logger.error("Failed to construct HTTP request")
     return
 }
+

--- a/templates/OperationResponseBodySnippet.stencil
+++ b/templates/OperationResponseBodySnippet.stencil
@@ -6,6 +6,8 @@
     {% include "OperationResponseStringBodySnippet.stencil" response %}
     {% elif response.strategy == "jsonBody" %}
     {% include "OperationResponseJsonBodySnippet.stencil" response %}
+    {% elif response.strategy == "unixTimeBody" %}
+    {% include "OperationResponseUnixTImeBodySnippet.stencil" response %}
     {% else %}
     // TODO: Couldn't find template for {{ exception.strategy }}
     {% endif %}

--- a/templates/OperationResponseDataSnippet.stencil
+++ b/templates/OperationResponseDataSnippet.stencil
@@ -5,10 +5,4 @@ guard let data = httpResponse?.data else {
     }
     return
 }
-guard let statusCode = httpResponse?.statusCode else {
-    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-    dispatchQueue.async {
-        completionHandler(.failure(noStatusCodeError), httpResponse)
-    }
-    return
-}
+

--- a/templates/OperationResponseSnippet.stencil
+++ b/templates/OperationResponseSnippet.stencil
@@ -1,6 +1,7 @@
 switch result {
 case .success:
 {% include "OperationResponseDataSnippet.stencil" %}
+{% include "OperationResponseStatusCodeDeclareSnippet.stencil" %}
 {% for response in op.responses %}
     {% if response.strategy == "pagedBody" %}
         {% include "OperationResponsePagedBodySnippet.stencil" op %}

--- a/templates/OperationResponseStatusCodeDeclareSnippet.stencil
+++ b/templates/OperationResponseStatusCodeDeclareSnippet.stencil
@@ -1,0 +1,7 @@
+guard let statusCode = httpResponse?.statusCode else {
+    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
+    dispatchQueue.async {
+        completionHandler(.failure(noStatusCodeError), httpResponse)
+    }
+    return
+}

--- a/templates/OperationResponseUnixTImeBodySnippet.stencil
+++ b/templates/OperationResponseUnixTImeBodySnippet.stencil
@@ -1,0 +1,12 @@
+{% include "OperationResponseNullableBodySnippet.stencil" %}
+if let decodedstr = String(data: data, encoding: .utf8),
+    let double = Double(decodedstr) {
+    let decoded = Date(timeIntervalSince1970: double) 
+    dispatchQueue.async {
+        completionHandler(.success(decoded), httpResponse)
+    }
+} else {
+    dispatchQueue.async {
+        completionHandler(.failure(AzureError.sdk("Decoding error.", nil)), httpResponse)
+    }
+}

--- a/templates/OperationSnippet.stencil
+++ b/templates/OperationSnippet.stencil
@@ -6,7 +6,7 @@
 ///     success.
 public func {{ op.name }}(
     {% include "BodyParamSnippet.stencil" op %}
-    {% for param in op.signatureParams %}
+    {% for param in op.params.signature %}
     {{ param.name }}: {{ param.type }}{{ param.defaultValue }},
     {% endfor %}
     withOptions options: {{ op.clientMethodOptions.name }}? = nil,
@@ -15,7 +15,7 @@ public func {{ op.name }}(
     {% include "OperationUrlSnippet.stencil" %}
     {% include "OperationQueryParamSnippet.stencil" %}
     {% include "OperationHeaderSnippet.stencil" %}
-    {% if op.params.hasOptionalsParams %}
+    {% if op.params.hasOptionalParams %}
     {% include "OperationOptionsSnippet.stencil" op %}
     {% endif %}
     {% include "OperationSendRequestSnippet.stencil" op %}

--- a/test/integration/generated/body-file/Source/AutoRestSwaggerBatFileClient.swift
+++ b/test/integration/generated/body-file/Source/AutoRestSwaggerBatFileClient.swift
@@ -119,6 +119,7 @@ public final class AutoRestSwaggerBatFileClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -144,13 +145,7 @@ public final class AutoRestSwaggerBatFileClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -220,6 +215,7 @@ public final class AutoRestSwaggerBatFileClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -245,13 +241,7 @@ public final class AutoRestSwaggerBatFileClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -321,6 +311,7 @@ public final class AutoRestSwaggerBatFileClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -346,13 +337,7 @@ public final class AutoRestSwaggerBatFileClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)

--- a/test/integration/generated/body-integer/Source/AutoRestIntegerTestClient.swift
+++ b/test/integration/generated/body-integer/Source/AutoRestIntegerTestClient.swift
@@ -736,14 +736,13 @@ public final class AutoRestIntegerTestClient: PipelineClient {
             self.options.logger.error("Failed to encode request body as json.")
             return
         }
-
         guard let requestUrl = url.appendingQueryParameters(queryParams) else {
-            self.options.logger.error("Failed to append query parameters to url")
+            self.options.logger.error("Failed to append query parameters to URL")
             return
         }
 
         guard let request = try? HTTPRequest(method: .put, url: requestUrl, headers: headers, data: requestBody) else {
-            self.options.logger.error("Failed to construct Http request")
+            self.options.logger.error("Failed to construct HTTP request")
             return
         }
 
@@ -844,14 +843,13 @@ public final class AutoRestIntegerTestClient: PipelineClient {
             self.options.logger.error("Failed to encode request body as json.")
             return
         }
-
         guard let requestUrl = url.appendingQueryParameters(queryParams) else {
-            self.options.logger.error("Failed to append query parameters to url")
+            self.options.logger.error("Failed to append query parameters to URL")
             return
         }
 
         guard let request = try? HTTPRequest(method: .put, url: requestUrl, headers: headers, data: requestBody) else {
-            self.options.logger.error("Failed to construct Http request")
+            self.options.logger.error("Failed to construct HTTP request")
             return
         }
 
@@ -952,14 +950,13 @@ public final class AutoRestIntegerTestClient: PipelineClient {
             self.options.logger.error("Failed to encode request body as json.")
             return
         }
-
         guard let requestUrl = url.appendingQueryParameters(queryParams) else {
-            self.options.logger.error("Failed to append query parameters to url")
+            self.options.logger.error("Failed to append query parameters to URL")
             return
         }
 
         guard let request = try? HTTPRequest(method: .put, url: requestUrl, headers: headers, data: requestBody) else {
-            self.options.logger.error("Failed to construct Http request")
+            self.options.logger.error("Failed to construct HTTP request")
             return
         }
 
@@ -1060,14 +1057,13 @@ public final class AutoRestIntegerTestClient: PipelineClient {
             self.options.logger.error("Failed to encode request body as json.")
             return
         }
-
         guard let requestUrl = url.appendingQueryParameters(queryParams) else {
-            self.options.logger.error("Failed to append query parameters to url")
+            self.options.logger.error("Failed to append query parameters to URL")
             return
         }
 
         guard let request = try? HTTPRequest(method: .put, url: requestUrl, headers: headers, data: requestBody) else {
-            self.options.logger.error("Failed to construct Http request")
+            self.options.logger.error("Failed to construct HTTP request")
             return
         }
 
@@ -1274,14 +1270,13 @@ public final class AutoRestIntegerTestClient: PipelineClient {
             self.options.logger.error("Failed to encode request body as json.")
             return
         }
-
         guard let requestUrl = url.appendingQueryParameters(queryParams) else {
-            self.options.logger.error("Failed to append query parameters to url")
+            self.options.logger.error("Failed to append query parameters to URL")
             return
         }
 
         guard let request = try? HTTPRequest(method: .put, url: requestUrl, headers: headers, data: requestBody) else {
-            self.options.logger.error("Failed to construct Http request")
+            self.options.logger.error("Failed to construct HTTP request")
             return
         }
 

--- a/test/integration/generated/body-integer/Source/AutoRestIntegerTestClient.swift
+++ b/test/integration/generated/body-integer/Source/AutoRestIntegerTestClient.swift
@@ -119,6 +119,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -155,13 +156,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -231,6 +226,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -260,13 +256,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -336,6 +326,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -365,13 +356,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -441,6 +426,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -470,13 +456,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -546,6 +526,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -575,13 +556,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -651,6 +626,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -680,13 +656,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -762,6 +732,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -787,13 +758,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -869,6 +834,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -894,13 +860,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -976,6 +936,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -1001,13 +962,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -1083,6 +1038,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -1108,13 +1064,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -1184,6 +1134,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -1194,15 +1145,15 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                 if [
                     200
                 ].contains(statusCode) {
-                    do {
-                        let decoder = JSONDecoder()
-                        let decoded = try decoder.decode(Date.self, from: data)
+                    if let decodedstr = String(data: data, encoding: .utf8),
+                        let double = Double(decodedstr) {
+                        let decoded = Date(timeIntervalSince1970: double)
                         dispatchQueue.async {
                             completionHandler(.success(decoded), httpResponse)
                         }
-                    } catch {
+                    } else {
                         dispatchQueue.async {
-                            completionHandler(.failure(AzureError.sdk("Decoding error.", error)), httpResponse)
+                            completionHandler(.failure(AzureError.sdk("Decoding error.", nil)), httpResponse)
                         }
                     }
                 }
@@ -1214,13 +1165,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -1296,6 +1241,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -1321,13 +1267,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -1397,6 +1337,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -1407,15 +1348,15 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                 if [
                     200
                 ].contains(statusCode) {
-                    do {
-                        let decoder = JSONDecoder()
-                        let decoded = try decoder.decode(Date.self, from: data)
+                    if let decodedstr = String(data: data, encoding: .utf8),
+                        let double = Double(decodedstr) {
+                        let decoded = Date(timeIntervalSince1970: double)
                         dispatchQueue.async {
                             completionHandler(.success(decoded), httpResponse)
                         }
-                    } catch {
+                    } else {
                         dispatchQueue.async {
-                            completionHandler(.failure(AzureError.sdk("Decoding error.", error)), httpResponse)
+                            completionHandler(.failure(AzureError.sdk("Decoding error.", nil)), httpResponse)
                         }
                     }
                 }
@@ -1427,13 +1368,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -1503,6 +1438,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -1520,15 +1456,15 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                         return
                     }
 
-                    do {
-                        let decoder = JSONDecoder()
-                        let decoded = try decoder.decode(Date.self, from: data)
+                    if let decodedstr = String(data: data, encoding: .utf8),
+                        let double = Double(decodedstr) {
+                        let decoded = Date(timeIntervalSince1970: double)
                         dispatchQueue.async {
                             completionHandler(.success(decoded), httpResponse)
                         }
-                    } catch {
+                    } else {
                         dispatchQueue.async {
-                            completionHandler(.failure(AzureError.sdk("Decoding error.", error)), httpResponse)
+                            completionHandler(.failure(AzureError.sdk("Decoding error.", nil)), httpResponse)
                         }
                     }
                 }
@@ -1540,13 +1476,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)

--- a/test/integration/generated/head/Source/AutoRestHeadTestClient.swift
+++ b/test/integration/generated/head/Source/AutoRestHeadTestClient.swift
@@ -118,6 +118,7 @@ public final class AutoRestHeadTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -206,6 +207,7 @@ public final class AutoRestHeadTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -294,6 +296,7 @@ public final class AutoRestHeadTestClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {

--- a/test/integration/generated/report/Source/AutoRestReportClient.swift
+++ b/test/integration/generated/report/Source/AutoRestReportClient.swift
@@ -128,6 +128,7 @@ public final class AutoRestReportClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -158,13 +159,7 @@ public final class AutoRestReportClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -243,6 +238,7 @@ public final class AutoRestReportClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -273,13 +269,7 @@ public final class AutoRestReportClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)

--- a/test/integration/generated/xms-error-responses/Source/XmsErrorResponseExtensionsClient.swift
+++ b/test/integration/generated/xms-error-responses/Source/XmsErrorResponseExtensionsClient.swift
@@ -120,6 +120,7 @@ public final class XmsErrorResponseExtensionsClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -252,6 +253,7 @@ public final class XmsErrorResponseExtensionsClient: PipelineClient {
                     }
                     return
                 }
+
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -297,13 +299,7 @@ public final class XmsErrorResponseExtensionsClient: PipelineClient {
                     }
                     return
                 }
-                guard let statusCode = httpResponse?.statusCode else {
-                    let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noStatusCodeError), httpResponse)
-                    }
-                    return
-                }
+
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(PetActionError.self, from: data)


### PR DESCRIPTION
* Add unixTimeBody strategy to decode UnixTime from data
* Refactor  templates/OperationResponseDataSnippet.stencil to break up into templates/OperationResponseStatusCodeDeclareSnippet.stencil and templates/OperationResponseDataSnippet.stencil
* Checked in regenerated code.
