### PR TITLE
Fix warnings when compile generated code for test swagger

### DIFF
--- a/src/AutorestSwift/View Models/OperationViewModel.swift
+++ b/src/AutorestSwift/View Models/OperationViewModel.swift
@@ -166,18 +166,19 @@ struct OperationViewModel {
 
     let params: OperationParameters
 
-    let returnType: ReturnTypeViewModel?
+    let returnType: ReturnTypeViewModel
 
     let clientMethodOptions: ClientMethodOptionsViewModel
 
-    let pipelineContext: [KeyValueViewModel]?
+    let pipelineContext: [KeyValueViewModel]
 
     let request: RequestViewModel
-    let responses: [ResponseViewModel]?
-    let exceptions: [ExceptionResponseViewModel]?
+    let responses: [ResponseViewModel]
+    let exceptions: [ExceptionResponseViewModel]
 
     let defaultException: ExceptionResponseViewModel?
     let defaultExceptionHasBody: Bool
+    let needHttpResponseData: Bool
 
     init(from operation: Operation, with model: CodeModel) {
         guard let request = operation.request else { fatalError("Request not found for operation \(operation.name).") }
@@ -224,9 +225,9 @@ struct OperationViewModel {
         self.responses = responses
         self.exceptions = exceptions
         self.defaultException = defaultException
-        self.defaultExceptionHasBody = (defaultException != nil) && defaultException?.objectType != "Void"
+        let defaultExceptionHasBody = (defaultException != nil) && defaultException?.objectType != "Void"
 
-        self.returnType = ReturnTypeViewModel(from: self.responses)
+        let returnType = ReturnTypeViewModel(from: self.responses)
 
         // create help struct to manage required and optional params in
         // headers/query/path, etc.
@@ -246,6 +247,10 @@ struct OperationViewModel {
             with: model,
             parameters: params.inOptions
         )
+
+        self.returnType = returnType
+        self.defaultExceptionHasBody = defaultExceptionHasBody
+        self.needHttpResponseData = exceptions.count > 1 || (returnType.name != "Void") || defaultExceptionHasBody
     }
 }
 

--- a/templates/OperationDefaultExceptionSnippet.stencil
+++ b/templates/OperationDefaultExceptionSnippet.stencil
@@ -1,6 +1,7 @@
 {% if op.defaultExceptionHasBody == true %}
-{% include "OperationResponseDataSnippet.stencil" %}
-{% include "OperationResponseFailureBodySnippet.stencil" %}
+case .failure:
+    {% include "OperationResponseFailureBodySnippet.stencil" %}
 {% else %}
-{% include "OperationResponseFailureNoBodySnippet.stencil" %}
+case let .failure(error):
+    {% include "OperationResponseFailureNoBodySnippet.stencil" %}
 {% endif %}

--- a/templates/OperationResponseDataSnippet.stencil
+++ b/templates/OperationResponseDataSnippet.stencil
@@ -1,3 +1,4 @@
+{% if op.needHttpResponseData %}
 guard let data = httpResponse?.data else {
     let noDataError = AzureError.sdk("Response data expected but not found.")
     dispatchQueue.async {
@@ -5,4 +6,5 @@ guard let data = httpResponse?.data else {
     }
     return
 }
+{% endif %}
 

--- a/templates/OperationResponseSnippet.stencil
+++ b/templates/OperationResponseSnippet.stencil
@@ -1,6 +1,6 @@
+{% include "OperationResponseDataSnippet.stencil" %}
 switch result {
 case .success:
-{% include "OperationResponseDataSnippet.stencil" %}
 {% include "OperationResponseStatusCodeDeclareSnippet.stencil" %}
 {% for response in op.responses %}
     {% if response.strategy == "pagedBody" %}
@@ -12,6 +12,5 @@ case .success:
     {% endif %}
 {% endfor %}
     {% include "OperationResponseExceptionSnippet.stencil" %}
-case let .failure(error):
-    {% include "OperationDefaultExceptionSnippet.stencil" %}
+{% include "OperationDefaultExceptionSnippet.stencil" %}
 }

--- a/test/integration/generated/body-file/Source/AutoRestSwaggerBatFileClient.swift
+++ b/test/integration/generated/body-file/Source/AutoRestSwaggerBatFileClient.swift
@@ -110,16 +110,16 @@ public final class AutoRestSwaggerBatFileClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -137,15 +137,7 @@ public final class AutoRestSwaggerBatFileClient: PipelineClient {
                         )
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -206,16 +198,16 @@ public final class AutoRestSwaggerBatFileClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -233,15 +225,7 @@ public final class AutoRestSwaggerBatFileClient: PipelineClient {
                         )
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -302,16 +286,16 @@ public final class AutoRestSwaggerBatFileClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -329,15 +313,7 @@ public final class AutoRestSwaggerBatFileClient: PipelineClient {
                         )
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)

--- a/test/integration/generated/body-integer/Source/AutoRestIntegerTestClient.swift
+++ b/test/integration/generated/body-integer/Source/AutoRestIntegerTestClient.swift
@@ -110,16 +110,16 @@ public final class AutoRestIntegerTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -148,15 +148,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                         }
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -217,16 +209,16 @@ public final class AutoRestIntegerTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -248,15 +240,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                         }
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -317,16 +301,16 @@ public final class AutoRestIntegerTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -348,15 +332,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                         }
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -417,16 +393,16 @@ public final class AutoRestIntegerTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -448,15 +424,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                         }
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -517,16 +485,16 @@ public final class AutoRestIntegerTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -548,15 +516,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                         }
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -617,16 +577,16 @@ public final class AutoRestIntegerTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -648,15 +608,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                         }
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -723,16 +675,16 @@ public final class AutoRestIntegerTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -750,15 +702,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                         )
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -825,16 +769,16 @@ public final class AutoRestIntegerTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -852,15 +796,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                         )
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -927,16 +863,16 @@ public final class AutoRestIntegerTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -954,15 +890,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                         )
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -1029,16 +957,16 @@ public final class AutoRestIntegerTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -1056,15 +984,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                         )
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -1125,16 +1045,16 @@ public final class AutoRestIntegerTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -1157,15 +1077,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                         }
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -1232,16 +1144,16 @@ public final class AutoRestIntegerTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -1259,15 +1171,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                         )
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -1328,16 +1232,16 @@ public final class AutoRestIntegerTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -1360,15 +1264,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                         }
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -1429,16 +1325,16 @@ public final class AutoRestIntegerTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -1468,15 +1364,7 @@ public final class AutoRestIntegerTestClient: PipelineClient {
                         }
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)

--- a/test/integration/generated/head/Source/AutoRestHeadTestClient.swift
+++ b/test/integration/generated/head/Source/AutoRestHeadTestClient.swift
@@ -109,16 +109,9 @@ public final class AutoRestHeadTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -198,16 +191,9 @@ public final class AutoRestHeadTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -287,16 +273,9 @@ public final class AutoRestHeadTestClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {

--- a/test/integration/generated/report/Source/AutoRestReportClient.swift
+++ b/test/integration/generated/report/Source/AutoRestReportClient.swift
@@ -119,16 +119,16 @@ public final class AutoRestReportClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -151,15 +151,7 @@ public final class AutoRestReportClient: PipelineClient {
                         }
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)
@@ -229,16 +221,16 @@ public final class AutoRestReportClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -261,15 +253,7 @@ public final class AutoRestReportClient: PipelineClient {
                         }
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(ErrorType.self, from: data)

--- a/test/integration/generated/xms-error-responses/Source/XmsErrorResponseExtensionsClient.swift
+++ b/test/integration/generated/xms-error-responses/Source/XmsErrorResponseExtensionsClient.swift
@@ -111,16 +111,16 @@ public final class XmsErrorResponseExtensionsClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -244,16 +244,16 @@ public final class XmsErrorResponseExtensionsClient: PipelineClient {
         context.add(cancellationToken: options?.cancellationToken, applying: self.options)
         self.request(request, context: context) { result, httpResponse in
             let dispatchQueue = options?.dispatchQueue ?? self.commonOptions.dispatchQueue ?? DispatchQueue.main
+            guard let data = httpResponse?.data else {
+                let noDataError = AzureError.sdk("Response data expected but not found.")
+                dispatchQueue.async {
+                    completionHandler(.failure(noDataError), httpResponse)
+                }
+                return
+            }
+
             switch result {
             case .success:
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
                 guard let statusCode = httpResponse?.statusCode else {
                     let noStatusCodeError = AzureError.sdk("Expected a status code in response but didn't find one.")
                     dispatchQueue.async {
@@ -291,15 +291,7 @@ public final class XmsErrorResponseExtensionsClient: PipelineClient {
                         }
                     }
                 }
-            case let .failure(error):
-                guard let data = httpResponse?.data else {
-                    let noDataError = AzureError.sdk("Response data expected but not found.")
-                    dispatchQueue.async {
-                        completionHandler(.failure(noDataError), httpResponse)
-                    }
-                    return
-                }
-
+            case .failure:
                 do {
                     let decoder = JSONDecoder()
                     let decoded = try decoder.decode(PetActionError.self, from: data)


### PR DESCRIPTION
* Include response data stencil only if needed
* Change 'case .failure' to use error only if needed
* Small clean in OperationViewModel to remove '?' for property which does not need to be nil-able.