### PR TITLE
Fix enumeration value to start with lower case letter

### DIFF
--- a/src/AutorestSwift/Utils/String+Extensions.swift
+++ b/src/AutorestSwift/Utils/String+Extensions.swift
@@ -84,4 +84,6 @@ extension String {
         let lastElementIndex = reversed().firstIndex(where: { !$0.isWhitespace })!
         return self[firstElementIndex ..< lastElementIndex.base]
     }
+
+    var lowercasedFirst: String { return prefix(1).lowercased() + dropFirst() }
 }

--- a/src/AutorestSwift/View Models/EnumerationChoiceViewModel.swift
+++ b/src/AutorestSwift/View Models/EnumerationChoiceViewModel.swift
@@ -36,7 +36,11 @@ struct EnumerationChoiceViewModel {
     let value: String
 
     init(from schema: ChoiceValue) {
-        self.name = schema.name
+        // Model4 passed in ChoiceValue name with first letter in Upper case despite the setting 
+        // for ChoiceValue is set to `camelcase` in README.md
+        // Enum value starts with an Upper case will cause swiftlint error and swiftlint autocorrect will not fix this issue.
+        // As a workaround, we lower caes the first letter of ChoiceValue in the view model.
+        self.name = schema.name.lowercasedFirst
         self.comment = ViewModelComment(from: schema.description)
         self.value = schema.value
     }

--- a/templates/Package.stencil
+++ b/templates/Package.stencil
@@ -26,13 +26,6 @@ let package = Package(
             dependencies: ["AzureCore"],
             path: "Source"
         ),
-        // TODO: Add test targets when test code is generated
-        // Test targets
-        //.testTarget(
-        //    name: "{{ model.name }}Tests",
-        //    dependencies: ["{{ model.name }}"],
-        //    sources: ["Tests"]
-        //),
     ],
     swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
* A fix for the swiftlint issue found in azure ios repo
* swiftlint failed because the enumeration value in the generated code start with an upper case despite the Model4 setting for choiceValue is set to `choiceValue:  camelcase`
* Apply this workaround for now to unblock by this issue.
* Remove the commented out code in Package.swift