### PR TITLE
Makefile updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,11 @@ test: copyTestResources
 	swift test
 
 clean:
-	find . -name \.build -type d -exec rm -rf \;
+	rm -rf .build
+	rm Package.resolved
+
+cleanAll:
+	find . -name \.build -type d -exec rm -rf {} \;
 	find . -name \Package.resolved -type f -delete
 
 .PHONY: run build test copyRunResources copyTestResources clean

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ RUN_RESOURCES_DIRECTORY = ${EXECUTABLE_DIRECTORY}
 
 build: copyRunResources
 	swift build --target AutorestSwift
+	./scripts/build_azure_core.sh
 	./scripts/swiftlint.sh
 
 copyRunResources:

--- a/scripts/build_azure_core.sh
+++ b/scripts/build_azure_core.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd ./test/integration/generated/head/
+swift build
+
+cd ../../../..


### PR DESCRIPTION
- Adds cleanAll to clean the root and test folders. 
- Keeps clean for just cleaning the root folder. 
- Updates make build to also rebuild AzureCore for use in tests following a cleanAll.