### PR TITLE
Remove compile warning in ArraySchema

### DIFF
--- a/AutorestSwiftTest/AutoRestReportTest.swift
+++ b/AutorestSwiftTest/AutoRestReportTest.swift
@@ -50,7 +50,7 @@ class AutoRestReportTest: XCTestCase {
         client.autorestreportservice.getReport { result, _ in
             switch result {
             case let .success(data):
-                XCTAssertEqual(data.count, 597)
+                XCTAssertEqual(data.count, 598)
                 XCTAssertEqual(data["MultipleInheritanceCatGet"], 0)
                 expectation.fulfill()
             case let .failure(error):
@@ -68,7 +68,7 @@ class AutoRestReportTest: XCTestCase {
         client.autorestreportservice.getOptionalReport { result, _ in
             switch result {
             case let .success(data):
-                XCTAssertEqual(data.count, 39)
+                XCTAssertEqual(data.count, 41)
                 XCTAssertEqual(data["getDecimalInvalid"], 0)
                 expectation.fulfill()
             case let .failure(error):

--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,8 @@ let package = Package(
             "XmsErrorResponseExtensions",
             "AutoRestReport",
             "AutoRestIntegerTest",
-            "AutoRestUrlTest",],
+            "AutoRestUrlTest",
+            "AutoRestResourceFlatteningTest"],
             path: "AutorestSwiftTest"
         )
     ],

--- a/src/AutorestSwift/Models/Complex/ArraySchema.swift
+++ b/src/AutorestSwift/Models/Complex/ArraySchema.swift
@@ -62,7 +62,7 @@ class ArraySchema: Schema {
     override func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        if elementType != nil { try container.encode(elementType, forKey: .elementType) }
+        try container.encode(elementType, forKey: .elementType)
         if maxItems != nil { try container.encode(maxItems, forKey: .maxItems) }
         if minItems != nil { try container.encode(minItems, forKey: .minItems) }
         if uniqueItems != nil { try container.encode(uniqueItems, forKey: .uniqueItems) }


### PR DESCRIPTION
Fix compile warning in ArraySchema.

```
AutorestSwift/Models/Complex/ArraySchema.swift:65:24: warning: comparing non-optional value of type 'Schema' to 'nil' always returns true
        if elementType != nil { try container.encode(elementType, forKey: .elementType) }


```