### PR TITLE
Add 10 test cases for body-string string operation

### DIFF
--- a/AutorestSwift.xcodeproj/project.pbxproj
+++ b/AutorestSwift.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		F15D30EF2548F38700265366 /* AutoRestUrlPathItemsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15D30EC2548F38700265366 /* AutoRestUrlPathItemsTest.swift */; };
 		F15D30F02548F38700265366 /* AutoRestUrlQueriesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15D30ED2548F38700265366 /* AutoRestUrlQueriesTest.swift */; };
 		F15D30F12548F38700265366 /* AutoRestUrlPathsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15D30EE2548F38700265366 /* AutoRestUrlPathsTest.swift */; };
+		F1660B51254CA88A00868BF2 /* OperationResponseByteArrayBodySnippet.stencil in CopyFiles */ = {isa = PBXBuildFile; fileRef = F1660B4F254CA85C00868BF2 /* OperationResponseByteArrayBodySnippet.stencil */; };
 		F170D322253F786800A569A0 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = F170D321253F786800A569A0 /* Util.swift */; };
 		F1731F322522E531006CDED8 /* MethodOptionsSnippet.stencil in CopyFiles */ = {isa = PBXBuildFile; fileRef = F1731F2E2522E4D8006CDED8 /* MethodOptionsSnippet.stencil */; };
 		F1731F332522E531006CDED8 /* NamedMethodOptionsFile.stencil in CopyFiles */ = {isa = PBXBuildFile; fileRef = F1731F2F2522E4F0006CDED8 /* NamedMethodOptionsFile.stencil */; };
@@ -253,6 +254,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 7;
 			files = (
+				F1660B51254CA88A00868BF2 /* OperationResponseByteArrayBodySnippet.stencil in CopyFiles */,
 				F1731F322522E531006CDED8 /* MethodOptionsSnippet.stencil in CopyFiles */,
 				F1731F332522E531006CDED8 /* NamedMethodOptionsFile.stencil in CopyFiles */,
 				F1731F342522E531006CDED8 /* OperationMethodDecodingSnippet.stencil in CopyFiles */,
@@ -432,6 +434,7 @@
 		F15D30EC2548F38700265366 /* AutoRestUrlPathItemsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoRestUrlPathItemsTest.swift; sourceTree = "<group>"; };
 		F15D30ED2548F38700265366 /* AutoRestUrlQueriesTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoRestUrlQueriesTest.swift; sourceTree = "<group>"; };
 		F15D30EE2548F38700265366 /* AutoRestUrlPathsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoRestUrlPathsTest.swift; sourceTree = "<group>"; };
+		F1660B4F254CA85C00868BF2 /* OperationResponseByteArrayBodySnippet.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OperationResponseByteArrayBodySnippet.stencil; sourceTree = "<group>"; };
 		F170D321253F786800A569A0 /* Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Util.swift; sourceTree = "<group>"; };
 		F1731F2E2522E4D8006CDED8 /* MethodOptionsSnippet.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = MethodOptionsSnippet.stencil; sourceTree = "<group>"; };
 		F1731F2F2522E4F0006CDED8 /* NamedMethodOptionsFile.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = NamedMethodOptionsFile.stencil; sourceTree = "<group>"; };
@@ -640,6 +643,7 @@
 				0A22B0BF24D32E7D00EC018E /* OperationOptionsSnippet.stencil */,
 				0A22B16724D36FB800EC018E /* OperationQueryParamSnippet.stencil */,
 				F1068F3C24D484A90082793F /* OperationRequestBodySnippet.stencil */,
+				F1660B4F254CA85C00868BF2 /* OperationResponseByteArrayBodySnippet.stencil */,
 				0A22B45A24DB59AA00EC018E /* OperationRequestPatchBodySnippet.stencil */,
 				0A22B0C724D3346A00EC018E /* OperationRequestSnippet.stencil */,
 				0A22B0C824D33F1000EC018E /* OperationResponseSnippet.stencil */,

--- a/AutorestSwiftTest/AutoRestSwaggerBatTest.swift
+++ b/AutorestSwiftTest/AutoRestSwaggerBatTest.swift
@@ -40,7 +40,7 @@ class AutoRestSwaggerBatTest: XCTestCase {
         )
     }
 
-    func test_string_getNull__200() throws {
+    func test_string_getNull_200() throws {
         let expectation = XCTestExpectation(description: "Call stringOperation.getNull")
 
         client.stringOperation.getNull { result, httpResponse in
@@ -48,6 +48,23 @@ class AutoRestSwaggerBatTest: XCTestCase {
             case let .success(data):
                 XCTAssertEqual(httpResponse?.statusCode, 200)
                 XCTAssertNil(data)
+            case let .failure(error):
+                let details = errorDetails(for: error, withResponse: httpResponse)
+                XCTFail("Call stringOperation.getNull failed error=\(details)")
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func test_string_putNull_200() throws {
+        let expectation = XCTestExpectation(description: "Call stringOperation.putNull")
+
+        client.stringOperation.put(null: nil) { result, httpResponse in
+            switch result {
+            case .success:
+                XCTAssertEqual(httpResponse?.statusCode, 200)
             case let .failure(error):
                 let details = errorDetails(for: error, withResponse: httpResponse)
                 XCTFail("Call stringOperation.getNull failed error=\(details)")

--- a/AutorestSwiftTest/AutoRestSwaggerBatTest.swift
+++ b/AutorestSwiftTest/AutoRestSwaggerBatTest.swift
@@ -74,4 +74,57 @@ class AutoRestSwaggerBatTest: XCTestCase {
 
         wait(for: [expectation], timeout: 5.0)
     }
+
+    func test_string_getEmpty_200() throws {
+        let expectation = XCTestExpectation(description: "Call stringOperation.getEmpty")
+
+        client.stringOperation.getEmpty { result, httpResponse in
+            switch result {
+            case let .success(data):
+                XCTAssertEqual(httpResponse?.statusCode, 200)
+                XCTAssertEqual(data, "\"\"")
+            case let .failure(error):
+                let details = errorDetails(for: error, withResponse: httpResponse)
+                XCTFail("Call stringOperation.getNull failed error=\(details)")
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func test_string_putEmpty_200() throws {
+        let expectation = XCTestExpectation(description: "Call stringOperation.putEmpty")
+
+        client.stringOperation.put(empty: "") { result, httpResponse in
+            switch result {
+            case .success:
+                XCTAssertEqual(httpResponse?.statusCode, 200)
+            case let .failure(error):
+                let details = errorDetails(for: error, withResponse: httpResponse)
+                XCTFail("Call stringOperation.putEmpty failed error=\(details)")
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func test_string_listMbcs_200() throws {
+        let expectation = XCTestExpectation(description: "Call stringOperation.listMbcs")
+
+        client.stringOperation.listMbcs { result, httpResponse in
+            switch result {
+            case let .success(data):
+                XCTAssertEqual(httpResponse?.statusCode, 200)
+                XCTAssertEqual(data.count, 70)
+            case let .failure(error):
+                let details = errorDetails(for: error, withResponse: httpResponse)
+                XCTFail("Call stringOperation.listMbcs failed error=\(details)")
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+    }
 }

--- a/AutorestSwiftTest/AutoRestSwaggerBatTest.swift
+++ b/AutorestSwiftTest/AutoRestSwaggerBatTest.swift
@@ -153,8 +153,6 @@ class AutoRestSwaggerBatTest: XCTestCase {
             switch result {
             case let .success(data):
                 XCTAssertEqual(httpResponse?.statusCode, 200)
-
-                print(data)
                 XCTAssertEqual(
                     data,
                     "\"    Now is the time for all good men to come to the aid of their country    \""

--- a/AutorestSwiftTest/AutoRestSwaggerBatTest.swift
+++ b/AutorestSwiftTest/AutoRestSwaggerBatTest.swift
@@ -127,4 +127,121 @@ class AutoRestSwaggerBatTest: XCTestCase {
 
         wait(for: [expectation], timeout: 5.0)
     }
+
+    func test_string_putMbcs_200() throws {
+        let expectation = XCTestExpectation(description: "Call stringOperation.putMbcs")
+
+        client.stringOperation
+            .put(mbcs: "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€") { result, httpResponse in
+                switch result {
+                case .success:
+                    XCTAssertEqual(httpResponse?.statusCode, 200)
+                case let .failure(error):
+                    let details = errorDetails(for: error, withResponse: httpResponse)
+                    XCTFail("Call stringOperation.putMbcs failed error=\(details)")
+                }
+                expectation.fulfill()
+            }
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func test_string_getWhitespace_200() throws {
+        let expectation = XCTestExpectation(description: "Call stringOperation.getWhitespace")
+
+        client.stringOperation.getWhitespace { result, httpResponse in
+            switch result {
+            case let .success(data):
+                XCTAssertEqual(httpResponse?.statusCode, 200)
+
+                print(data)
+                XCTAssertEqual(
+                    data,
+                    "\"    Now is the time for all good men to come to the aid of their country    \""
+                )
+            case let .failure(error):
+                let details = errorDetails(for: error, withResponse: httpResponse)
+                XCTFail("Call stringOperation.getWhitespace failed error=\(details)")
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func test_string_putWhitespace_200() throws {
+        let expectation = XCTestExpectation(description: "Call stringOperation.putWhitespace")
+
+        client.stringOperation
+            .put(whitespace: "    Now is the time for all good men to come to the aid of their country    ") { result, httpResponse in
+                switch result {
+                case .success:
+                    XCTAssertEqual(httpResponse?.statusCode, 200)
+                case let .failure(error):
+                    let details = errorDetails(for: error, withResponse: httpResponse)
+                    XCTFail("Call stringOperation.putWhitespace failed error=\(details)")
+                }
+                expectation.fulfill()
+            }
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func test_string_getNotProvided_200() throws {
+        let expectation = XCTestExpectation(description: "Call stringOperation.getNotProvided")
+
+        client.stringOperation.getNotProvided { result, httpResponse in
+            switch result {
+            case let .success(data):
+                XCTAssertEqual(httpResponse?.statusCode, 200)
+                XCTAssertEqual(data, "")
+            case let .failure(error):
+                let details = errorDetails(for: error, withResponse: httpResponse)
+                XCTFail("Call getNotProvided.putWhitespace failed error=\(details)")
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func test_string_getBase64Encoded_200() throws {
+        let expectation = XCTestExpectation(description: "Call stringOperation.getBase64Encoded")
+
+        client.stringOperation.getBase64Encoded { result, httpResponse in
+            switch result {
+            case let .success(data):
+                XCTAssertEqual(httpResponse?.statusCode, 200)
+                XCTAssertEqual(
+                    String(decoding: data, as: UTF8.self),
+                    "\"YSBzdHJpbmcgdGhhdCBnZXRzIGVuY29kZWQgd2l0aCBiYXNlNjQ=\""
+                )
+            case let .failure(error):
+                let details = errorDetails(for: error, withResponse: httpResponse)
+                XCTFail("Call getNotProvided.getBase64Encoded failed error=\(details)")
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+
+    func test_string_getBase64UrlEncoded_200() throws {
+        let expectation = XCTestExpectation(description: "Call stringOperation.getBase64UrlEncoded")
+
+        client.stringOperation.getBase64UrlEncoded { result, httpResponse in
+            switch result {
+            case let .success(data):
+                XCTAssertEqual(httpResponse?.statusCode, 200)
+                let str = String(decoding: data, as: UTF8.self)
+                XCTAssertEqual(str, "\"YSBzdHJpbmcgdGhhdCBnZXRzIGVuY29kZWQgd2l0aCBiYXNlNjR1cmw\"")
+            case let .failure(error):
+                let details = errorDetails(for: error, withResponse: httpResponse)
+                XCTFail("Call getNotProvided.getBase64UrlEncoded failed error=\(details)")
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+    }
 }

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   },
   "homepage": "https://github.com/Azure/autorest.swift/blob/master/README.md",
   "dependencies": {
-    "@azure-tools/extension": "^3.0.249"
+    "@azure-tools/extension": "^3.0.263"
   },
   "devDependencies": {
     "@autorest/autorest": "^3.0.0",
-    "@microsoft.azure/autorest.testserver": "2.10.54"
+    "@microsoft.azure/autorest.testserver": "^2.10.61"
   }
 }

--- a/src/AutorestSwift/Models/Complex/Parameter.swift
+++ b/src/AutorestSwift/Models/Complex/Parameter.swift
@@ -114,12 +114,13 @@ class Parameter: Value, CustomDebugStringConvertible {
     }
 
     internal func belongsInOptions() -> Bool {
-        let inMethod = implementation == .method
+        let inMethodImplementation = implementation == .method
         let notConstant = schema!.type != .constant
         let notFlattened = flattened != true
         let notGrouped = groupedBy == nil
         let notRequired = required == false
-        return notRequired && inMethod && notConstant && notFlattened && notGrouped
+        let inBodyLocation = paramLocation == .body
+        return notRequired && inMethodImplementation && notConstant && notFlattened && notGrouped && !inBodyLocation
     }
 }
 

--- a/src/AutorestSwift/Models/Complex/ParameterType.swift
+++ b/src/AutorestSwift/Models/Complex/ParameterType.swift
@@ -109,6 +109,10 @@ enum ParameterType: Codable {
         return common.groupedBy
     }
 
+    var nullable: Bool {
+        return common.nullable ?? false
+    }
+
     /// Return the common base class Parameter properties
     private var common: Parameter {
         switch self {

--- a/src/AutorestSwift/View Models/OperationViewModel.swift
+++ b/src/AutorestSwift/View Models/OperationViewModel.swift
@@ -127,6 +127,7 @@ enum BodyParamStrategy: String {
     case plain
     case flattened
     case unixTime
+    case plainNullable
 }
 
 struct BodyParams {
@@ -153,7 +154,7 @@ struct BodyParams {
         }
 
         let strategy: BodyParamStrategy = param.flattened ? .flattened : param.schema.type == AllSchemaTypes
-            .unixTime ? .unixTime : .plain
+            .unixTime ? .unixTime : param.nullable ? .plainNullable : .plain
         self.strategy = strategy.rawValue
         self.children = virtParams
     }

--- a/src/AutorestSwift/View Models/OperationViewModel.swift
+++ b/src/AutorestSwift/View Models/OperationViewModel.swift
@@ -168,7 +168,11 @@ struct VirtualParam {
 
     init(from param: VirtualParameter) {
         self.name = param.name
-        self.path = param.targetProperty.name
+        var path = param.targetProperty.name
+        if let groupBy = param.groupedBy?.name {
+            path = "\(groupBy).\(path)"
+        }
+        self.path = path
         self.type = param.schema!.swiftType(optional: !param.required)
         self.defaultValue = param.required ? "" : " = nil"
     }

--- a/src/AutorestSwift/View Models/OperationViewModel.swift
+++ b/src/AutorestSwift/View Models/OperationViewModel.swift
@@ -153,8 +153,18 @@ struct BodyParams {
             }
         }
 
-        let strategy: BodyParamStrategy = param.flattened ? .flattened : param.schema.type == AllSchemaTypes
-            .unixTime ? .unixTime : param.nullable ? .plainNullable : .plain
+        var strategy: BodyParamStrategy = .plain
+
+        if param.flattened {
+            strategy = .flattened
+        } else if param.nullable {
+            strategy = .plainNullable
+        } else if param.schema.type == .unixTime {
+            strategy = .unixTime
+        } else {
+            strategy = .plain
+        }
+
         self.strategy = strategy.rawValue
         self.children = virtParams
     }

--- a/src/AutorestSwift/View Models/ResponseViewModel.swift
+++ b/src/AutorestSwift/View Models/ResponseViewModel.swift
@@ -39,6 +39,8 @@ enum ResponseBodyType: String {
     case jsonBody
     /// Service returns a unixTime body
     case unixTimeBody
+    /// Service returns a byteArray body
+    case byteArrayBody
 
     static func strategy(for input: String, and type: AllSchemaTypes) -> ResponseBodyType {
         if input == "String" {
@@ -47,6 +49,8 @@ enum ResponseBodyType: String {
             return .intBody
         } else if input == "Date", type == .unixTime {
             return .unixTimeBody
+        } else if input == "Data", type == .byteArray {
+            return .byteArrayBody
         } else {
             return .jsonBody
         }

--- a/templates/BodyParamSnippet.stencil
+++ b/templates/BodyParamSnippet.stencil
@@ -1,3 +1,3 @@
-{% if op.params.body.strategy != "flattened" %}
+{% if op.params.body.strategy == "plain" or op.params.body.strategy == "unixTime" or op.params.body.strategy == "plainNullable" %}
     {{ op.params.body.param.name }}: {{ op.params.body.param.type }},
 {% endif %}

--- a/templates/BodyParamSnippet.stencil
+++ b/templates/BodyParamSnippet.stencil
@@ -1,3 +1,3 @@
-{% if op.params.body.strategy == "plain" or op.params.body.strategy == "unixTime" or op.params.body.strategy == "plainNullable" or op.params.body.strategy == "byteArray" %}
+{% if op.params.body.strategy != "flattened" %}
     {{ op.params.body.param.name }}: {{ op.params.body.param.type }},
 {% endif %}

--- a/templates/BodyParamSnippet.stencil
+++ b/templates/BodyParamSnippet.stencil
@@ -1,3 +1,3 @@
 {% if op.params.body.strategy == "plain" or op.params.body.strategy == "unixTime" or op.params.body.strategy == "plainNullable" %}
-    {{ op.params.body.param.name }}: {{ op.params.body.param.type }}{{ op.params.body.param.defaultValue }},
+    {{ op.params.body.param.name }}: {{ op.params.body.param.type }},
 {% endif %}

--- a/templates/BodyParamSnippet.stencil
+++ b/templates/BodyParamSnippet.stencil
@@ -1,3 +1,3 @@
-{% if op.params.body.strategy == "plain" or op.params.body.strategy == "unixTime"  %}
+{% if op.params.body.strategy == "plain" or op.params.body.strategy == "unixTime" or op.params.body.strategy == "plainNullable" %}
     {{ op.params.body.param.name }}: {{ op.params.body.param.type }}{{ op.params.body.param.defaultValue }},
 {% endif %}

--- a/templates/BodyParamSnippet.stencil
+++ b/templates/BodyParamSnippet.stencil
@@ -1,3 +1,3 @@
-{% if op.params.body.strategy == "plain" or op.params.body.strategy == "unixTime" or op.params.body.strategy == "plainNullable" %}
+{% if op.params.body.strategy == "plain" or op.params.body.strategy == "unixTime" or op.params.body.strategy == "plainNullable" or op.params.body.strategy == "byteArray" %}
     {{ op.params.body.param.name }}: {{ op.params.body.param.type }},
 {% endif %}

--- a/templates/OperationRequestBodySnippet.stencil
+++ b/templates/OperationRequestBodySnippet.stencil
@@ -4,6 +4,16 @@ guard let requestBody = try? JSONEncoder().encode( {{ op.params.body.param.name 
     self.options.logger.error("Failed to encode request body as json.")
     return
 }
+{% elif op.params.body.strategy == "plainNullable" %}
+var requestBody: Data? = nil
+if ({{ op.params.body.param.name }} != nil)
+{
+    guard let encodedRequestBody = try? JSONEncoder().encode( {{ op.params.body.param.name }} ) else {
+        self.options.logger.error("Failed to encode request body as json.")
+        return
+    }
+    requestBody = encodedRequestBody
+}
 {% elif op.params.body.strategy == "unixTime" %}
 let encoder = JSONEncoder()
 encoder.dateEncodingStrategy = .secondsSince1970

--- a/templates/OperationResponseBodySnippet.stencil
+++ b/templates/OperationResponseBodySnippet.stencil
@@ -8,6 +8,8 @@
     {% include "OperationResponseJsonBodySnippet.stencil" response %}
     {% elif response.strategy == "unixTimeBody" %}
     {% include "OperationResponseUnixTImeBodySnippet.stencil" response %}
+    {% elif response.strategy == "byteArrayBody" %}
+    {% include "OperationResponseByteArrayBodySnippet.stencil" response %}
     {% else %}
     // TODO: Couldn't find template for {{ exception.strategy }}
     {% endif %}

--- a/templates/OperationResponseByteArrayBodySnippet.stencil
+++ b/templates/OperationResponseByteArrayBodySnippet.stencil
@@ -1,0 +1,4 @@
+{% include "OperationResponseNullableBodySnippet.stencil" %}
+dispatchQueue.async {
+    completionHandler(.success(data), httpResponse)
+}

--- a/test/integration/generated/body-integer/Source/IntOperation.swift
+++ b/test/integration/generated/body-integer/Source/IntOperation.swift
@@ -614,7 +614,7 @@ public final class IntOperation {
 
     /// Put max int32 value
     /// - Parameters:
-    ///    - max32 :
+    ///    - max32 : int body
     ///    - options: A list of options for the operation
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
@@ -709,7 +709,7 @@ public final class IntOperation {
 
     /// Put max int64 value
     /// - Parameters:
-    ///    - max64 :
+    ///    - max64 : int body
     ///    - options: A list of options for the operation
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
@@ -804,7 +804,7 @@ public final class IntOperation {
 
     /// Put min int32 value
     /// - Parameters:
-    ///    - min32 :
+    ///    - min32 : int body
     ///    - options: A list of options for the operation
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
@@ -899,7 +899,7 @@ public final class IntOperation {
 
     /// Put min int64 value
     /// - Parameters:
-    ///    - min64 :
+    ///    - min64 : int body
     ///    - options: A list of options for the operation
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
@@ -1088,7 +1088,7 @@ public final class IntOperation {
 
     /// Put datetime encoded as Unix time
     /// - Parameters:
-    ///    - unixTimeDate :
+    ///    - unixTimeDate : int body
     ///    - options: A list of options for the operation
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.

--- a/test/integration/generated/body-string/Source/EnumOperation.swift
+++ b/test/integration/generated/body-string/Source/EnumOperation.swift
@@ -143,7 +143,7 @@ public final class EnumOperation {
 
     /// Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
     /// - Parameters:
-    ///    - notExpandable :
+    ///    - notExpandable : string body
     ///    - options: A list of options for the operation
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
@@ -332,7 +332,7 @@ public final class EnumOperation {
 
     /// Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
     /// - Parameters:
-    ///    - referenced :
+    ///    - referenced : enum string body
     ///    - options: A list of options for the operation
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
@@ -521,7 +521,7 @@ public final class EnumOperation {
 
     /// Sends value 'green-color' from a constant
     /// - Parameters:
-    ///    - referencedConstant :
+    ///    - referencedConstant : enum string body
     ///    - options: A list of options for the operation
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.

--- a/test/integration/generated/body-string/Source/Options/StringOperation+PutNullOptions.swift
+++ b/test/integration/generated/body-string/Source/Options/StringOperation+PutNullOptions.swift
@@ -18,8 +18,6 @@ import Foundation
 extension StringOperation {
     /// User-configurable options for the `AutoRestSwaggerBATService.PutNull` operation.
     public struct PutNullOptions: RequestOptions {
-        public let stringBody: String?
-
         /// A client-generated, opaque value with 1KB character limit that is recorded in analytics logs.
         /// Highly recommended for correlating client-side activites with requests received by the server.
         public let clientRequestId: String?
@@ -32,17 +30,14 @@ extension StringOperation {
 
         /// Initialize a `PutNullOptions` structure.
         /// - Parameters:
-        ///   - stringBody:
         ///   - clientRequestId: A client-generated, opaque value with 1KB character limit that is recorded in analytics logs.
         ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
         ///   - dispatchQueue: A dispatch queue on which to call the completion handler. Defaults to `DispatchQueue.main`.
         public init(
-            stringBody: String? = nil,
             clientRequestId: String? = nil,
             cancellationToken: CancellationToken? = nil,
             dispatchQueue: DispatchQueue? = nil
         ) {
-            self.stringBody = stringBody
             self.clientRequestId = clientRequestId
             self.cancellationToken = cancellationToken
             self.dispatchQueue = dispatchQueue

--- a/test/integration/generated/body-string/Source/StringOperation.swift
+++ b/test/integration/generated/body-string/Source/StringOperation.swift
@@ -171,9 +171,13 @@ public final class StringOperation {
         headers["Content-Type"] = "application/json"
         headers["Accept"] = "application/json"
         // Construct request
-        guard let requestBody = try? JSONEncoder().encode(null) else {
-            self.options.logger.error("Failed to encode request body as json.")
-            return
+        var requestBody: Data?
+        if null != nil {
+            guard let encodedRequestBody = try? JSONEncoder().encode(null) else {
+                self.options.logger.error("Failed to encode request body as json.")
+                return
+            }
+            requestBody = encodedRequestBody
         }
         guard let requestUrl = url(
             host: "{$host}",

--- a/test/integration/generated/body-string/Source/StringOperation.swift
+++ b/test/integration/generated/body-string/Source/StringOperation.swift
@@ -338,11 +338,12 @@ public final class StringOperation {
 
     /// Set string value empty ''
     /// - Parameters:
-
+    ///    - empty :
     ///    - options: A list of options for the operation
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
-    public func putEmpty(
+    public func put(
+        empty: String,
         withOptions options: PutEmptyOptions? = nil,
         completionHandler: @escaping HTTPResultHandler<Void>
     ) {
@@ -360,6 +361,10 @@ public final class StringOperation {
         headers["Content-Type"] = "application/json"
         headers["Accept"] = "application/json"
         // Construct request
+        guard let requestBody = try? JSONEncoder().encode(empty) else {
+            self.options.logger.error("Failed to encode request body as json.")
+            return
+        }
         guard let requestUrl = url(
             host: "{$host}",
             template: urlTemplate,
@@ -370,8 +375,8 @@ public final class StringOperation {
             return
         }
 
-        guard let request = try? HTTPRequest(method: .put, url: requestUrl, headers: headers) else {
-            self.options.logger.error("Failed to construct Http request")
+        guard let request = try? HTTPRequest(method: .put, url: requestUrl, headers: headers, data: requestBody) else {
+            self.options.logger.error("Failed to construct HTTP request")
             return
         }
 
@@ -519,11 +524,12 @@ public final class StringOperation {
 
     /// Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
     /// - Parameters:
-
+    ///    - mbcs :
     ///    - options: A list of options for the operation
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
-    public func putMbcs(
+    public func put(
+        mbcs: String,
         withOptions options: PutMbcsOptions? = nil,
         completionHandler: @escaping HTTPResultHandler<Void>
     ) {
@@ -541,6 +547,10 @@ public final class StringOperation {
         headers["Content-Type"] = "application/json"
         headers["Accept"] = "application/json"
         // Construct request
+        guard let requestBody = try? JSONEncoder().encode(mbcs) else {
+            self.options.logger.error("Failed to encode request body as json.")
+            return
+        }
         guard let requestUrl = url(
             host: "{$host}",
             template: urlTemplate,
@@ -551,8 +561,8 @@ public final class StringOperation {
             return
         }
 
-        guard let request = try? HTTPRequest(method: .put, url: requestUrl, headers: headers) else {
-            self.options.logger.error("Failed to construct Http request")
+        guard let request = try? HTTPRequest(method: .put, url: requestUrl, headers: headers, data: requestBody) else {
+            self.options.logger.error("Failed to construct HTTP request")
             return
         }
 
@@ -700,11 +710,12 @@ public final class StringOperation {
 
     /// Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
     /// - Parameters:
-
+    ///    - whitespace :
     ///    - options: A list of options for the operation
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
-    public func putWhitespace(
+    public func put(
+        whitespace: String,
         withOptions options: PutWhitespaceOptions? = nil,
         completionHandler: @escaping HTTPResultHandler<Void>
     ) {
@@ -722,6 +733,10 @@ public final class StringOperation {
         headers["Content-Type"] = "application/json"
         headers["Accept"] = "application/json"
         // Construct request
+        guard let requestBody = try? JSONEncoder().encode(whitespace) else {
+            self.options.logger.error("Failed to encode request body as json.")
+            return
+        }
         guard let requestUrl = url(
             host: "{$host}",
             template: urlTemplate,
@@ -732,8 +747,8 @@ public final class StringOperation {
             return
         }
 
-        guard let request = try? HTTPRequest(method: .put, url: requestUrl, headers: headers) else {
-            self.options.logger.error("Failed to construct Http request")
+        guard let request = try? HTTPRequest(method: .put, url: requestUrl, headers: headers, data: requestBody) else {
+            self.options.logger.error("Failed to construct HTTP request")
             return
         }
 

--- a/test/integration/generated/body-string/Source/StringOperation.swift
+++ b/test/integration/generated/body-string/Source/StringOperation.swift
@@ -153,7 +153,7 @@ public final class StringOperation {
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
     public func put(
-        null: String? = nil,
+        null: String?,
         withOptions options: PutNullOptions? = nil,
         completionHandler: @escaping HTTPResultHandler<Void>
     ) {

--- a/test/integration/generated/body-string/Source/StringOperation.swift
+++ b/test/integration/generated/body-string/Source/StringOperation.swift
@@ -149,7 +149,7 @@ public final class StringOperation {
 
     /// Set string value null
     /// - Parameters:
-    ///    - null :
+    ///    - null : string body
     ///    - options: A list of options for the operation
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
@@ -341,7 +341,7 @@ public final class StringOperation {
 
     /// Set string value empty ''
     /// - Parameters:
-    ///    - empty :
+    ///    - empty : string body
     ///    - options: A list of options for the operation
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
@@ -529,7 +529,7 @@ public final class StringOperation {
 
     /// Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
     /// - Parameters:
-    ///    - mbcs :
+    ///    - mbcs : string body
     ///    - options: A list of options for the operation
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
@@ -717,7 +717,7 @@ public final class StringOperation {
 
     /// Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
     /// - Parameters:
-    ///    - whitespace :
+    ///    - whitespace : string body
     ///    - options: A list of options for the operation
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
@@ -1077,7 +1077,7 @@ public final class StringOperation {
 
     /// Put value that is base64url encoded
     /// - Parameters:
-    ///    - base64UrlEncoded :
+    ///    - base64UrlEncoded : string body
     ///    - options: A list of options for the operation
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.

--- a/test/integration/generated/body-string/Source/StringOperation.swift
+++ b/test/integration/generated/body-string/Source/StringOperation.swift
@@ -959,16 +959,8 @@ public final class StringOperation {
                 if [
                     200
                 ].contains(statusCode) {
-                    do {
-                        let decoder = JSONDecoder()
-                        let decoded = try decoder.decode(Data.self, from: data)
-                        dispatchQueue.async {
-                            completionHandler(.success(decoded), httpResponse)
-                        }
-                    } catch {
-                        dispatchQueue.async {
-                            completionHandler(.failure(AzureError.client("Decoding error.", error)), httpResponse)
-                        }
+                    dispatchQueue.async {
+                        completionHandler(.success(data), httpResponse)
                     }
                 }
             case .failure:
@@ -1052,16 +1044,8 @@ public final class StringOperation {
                 if [
                     200
                 ].contains(statusCode) {
-                    do {
-                        let decoder = JSONDecoder()
-                        let decoded = try decoder.decode(Data.self, from: data)
-                        dispatchQueue.async {
-                            completionHandler(.success(decoded), httpResponse)
-                        }
-                    } catch {
-                        dispatchQueue.async {
-                            completionHandler(.failure(AzureError.client("Decoding error.", error)), httpResponse)
-                        }
+                    dispatchQueue.async {
+                        completionHandler(.success(data), httpResponse)
                     }
                 }
             case .failure:
@@ -1246,16 +1230,8 @@ public final class StringOperation {
                         return
                     }
 
-                    do {
-                        let decoder = JSONDecoder()
-                        let decoded = try decoder.decode(Data.self, from: data)
-                        dispatchQueue.async {
-                            completionHandler(.success(decoded), httpResponse)
-                        }
-                    } catch {
-                        dispatchQueue.async {
-                            completionHandler(.failure(AzureError.client("Decoding error.", error)), httpResponse)
-                        }
+                    dispatchQueue.async {
+                        completionHandler(.success(data), httpResponse)
                     }
                 }
             case .failure:

--- a/test/integration/generated/model-flattening/Source/AutoRestResourceFlatteningTestService.swift
+++ b/test/integration/generated/model-flattening/Source/AutoRestResourceFlatteningTestService.swift
@@ -1031,6 +1031,15 @@ public final class AutoRestResourceFlatteningTestService {
         headers["Content-Type"] = "application/json"
         headers["Accept"] = "application/json"
         // Construct request
+        let body = SimpleProduct(
+            maxProductDisplayName: flattenParameterGroup.maxProductDisplayName,
+            genericValue: flattenParameterGroup.genericValue, odataValue: flattenParameterGroup.odataValue,
+            productId: flattenParameterGroup.productId, description: flattenParameterGroup.description
+        )
+        guard let requestBody = try? JSONEncoder().encode(body) else {
+            self.options.logger.error("Failed to encode request body as json.")
+            return
+        }
         guard let requestUrl = url(
             host: "{$host}",
             template: urlTemplate,
@@ -1041,8 +1050,8 @@ public final class AutoRestResourceFlatteningTestService {
             return
         }
 
-        guard let request = try? HTTPRequest(method: .put, url: requestUrl, headers: headers) else {
-            self.options.logger.error("Failed to construct Http request")
+        guard let request = try? HTTPRequest(method: .put, url: requestUrl, headers: headers, data: requestBody) else {
+            self.options.logger.error("Failed to construct HTTP request")
             return
         }
 

--- a/test/integration/generated/model-flattening/Source/AutoRestResourceFlatteningTestService.swift
+++ b/test/integration/generated/model-flattening/Source/AutoRestResourceFlatteningTestService.swift
@@ -54,7 +54,7 @@ public final class AutoRestResourceFlatteningTestService {
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
     public func put(
-        array: [Resource]? = nil,
+        array: [Resource]?,
         withOptions options: PutArrayOptions? = nil,
         completionHandler: @escaping HTTPResultHandler<Void>
     ) {
@@ -241,7 +241,7 @@ public final class AutoRestResourceFlatteningTestService {
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
     public func put(
-        wrappedArray: [WrappedProduct]? = nil,
+        wrappedArray: [WrappedProduct]?,
         withOptions options: PutWrappedArrayOptions? = nil,
         completionHandler: @escaping HTTPResultHandler<Void>
     ) {
@@ -428,7 +428,7 @@ public final class AutoRestResourceFlatteningTestService {
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
     public func put(
-        dictionary: [String: FlattenedProduct]? = nil,
+        dictionary: [String: FlattenedProduct]?,
         withOptions options: PutDictionaryOptions? = nil,
         completionHandler: @escaping HTTPResultHandler<Void>
     ) {
@@ -615,7 +615,7 @@ public final class AutoRestResourceFlatteningTestService {
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
     public func put(
-        resourceCollection: ResourceCollection? = nil,
+        resourceCollection: ResourceCollection?,
         withOptions options: PutResourceCollectionOptions? = nil,
         completionHandler: @escaping HTTPResultHandler<Void>
     ) {
@@ -802,7 +802,7 @@ public final class AutoRestResourceFlatteningTestService {
     ///    - completionHandler: A completion handler that receives a status code on
     ///     success.
     public func put(
-        simpleProduct: SimpleProduct? = nil,
+        simpleProduct: SimpleProduct?,
         withOptions options: PutSimpleProductOptions? = nil,
         completionHandler: @escaping HTTPResultHandler<SimpleProduct>
     ) {

--- a/test/integration/generated/model-flattening/Source/Options/AutoRestResourceFlatteningTestService+PutArrayOptions.swift
+++ b/test/integration/generated/model-flattening/Source/Options/AutoRestResourceFlatteningTestService+PutArrayOptions.swift
@@ -18,9 +18,6 @@ import Foundation
 extension AutoRestResourceFlatteningTestService {
     /// User-configurable options for the `AutoRestResourceFlatteningTestService.PutArray` operation.
     public struct PutArrayOptions: RequestOptions {
-        /// External Resource as an Array to put
-        public let resourceArray: [Resource]?
-
         /// A client-generated, opaque value with 1KB character limit that is recorded in analytics logs.
         /// Highly recommended for correlating client-side activites with requests received by the server.
         public let clientRequestId: String?
@@ -33,17 +30,14 @@ extension AutoRestResourceFlatteningTestService {
 
         /// Initialize a `PutArrayOptions` structure.
         /// - Parameters:
-        ///   - resourceArray: External Resource as an Array to put
         ///   - clientRequestId: A client-generated, opaque value with 1KB character limit that is recorded in analytics logs.
         ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
         ///   - dispatchQueue: A dispatch queue on which to call the completion handler. Defaults to `DispatchQueue.main`.
         public init(
-            resourceArray: [Resource]? = nil,
             clientRequestId: String? = nil,
             cancellationToken: CancellationToken? = nil,
             dispatchQueue: DispatchQueue? = nil
         ) {
-            self.resourceArray = resourceArray
             self.clientRequestId = clientRequestId
             self.cancellationToken = cancellationToken
             self.dispatchQueue = dispatchQueue

--- a/test/integration/generated/model-flattening/Source/Options/AutoRestResourceFlatteningTestService+PutDictionaryOptions.swift
+++ b/test/integration/generated/model-flattening/Source/Options/AutoRestResourceFlatteningTestService+PutDictionaryOptions.swift
@@ -18,9 +18,6 @@ import Foundation
 extension AutoRestResourceFlatteningTestService {
     /// User-configurable options for the `AutoRestResourceFlatteningTestService.PutDictionary` operation.
     public struct PutDictionaryOptions: RequestOptions {
-        /// External Resource as a Dictionary to put
-        public let resourceDictionary: [String: FlattenedProduct]?
-
         /// A client-generated, opaque value with 1KB character limit that is recorded in analytics logs.
         /// Highly recommended for correlating client-side activites with requests received by the server.
         public let clientRequestId: String?
@@ -33,17 +30,14 @@ extension AutoRestResourceFlatteningTestService {
 
         /// Initialize a `PutDictionaryOptions` structure.
         /// - Parameters:
-        ///   - resourceDictionary: External Resource as a Dictionary to put
         ///   - clientRequestId: A client-generated, opaque value with 1KB character limit that is recorded in analytics logs.
         ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
         ///   - dispatchQueue: A dispatch queue on which to call the completion handler. Defaults to `DispatchQueue.main`.
         public init(
-            resourceDictionary: [String: FlattenedProduct]? = nil,
             clientRequestId: String? = nil,
             cancellationToken: CancellationToken? = nil,
             dispatchQueue: DispatchQueue? = nil
         ) {
-            self.resourceDictionary = resourceDictionary
             self.clientRequestId = clientRequestId
             self.cancellationToken = cancellationToken
             self.dispatchQueue = dispatchQueue

--- a/test/integration/generated/model-flattening/Source/Options/AutoRestResourceFlatteningTestService+PutResourceCollectionOptions.swift
+++ b/test/integration/generated/model-flattening/Source/Options/AutoRestResourceFlatteningTestService+PutResourceCollectionOptions.swift
@@ -18,9 +18,6 @@ import Foundation
 extension AutoRestResourceFlatteningTestService {
     /// User-configurable options for the `AutoRestResourceFlatteningTestService.PutResourceCollection` operation.
     public struct PutResourceCollectionOptions: RequestOptions {
-        /// External Resource as a ResourceCollection to put
-        public let resourceComplexObject: ResourceCollection?
-
         /// A client-generated, opaque value with 1KB character limit that is recorded in analytics logs.
         /// Highly recommended for correlating client-side activites with requests received by the server.
         public let clientRequestId: String?
@@ -33,17 +30,14 @@ extension AutoRestResourceFlatteningTestService {
 
         /// Initialize a `PutResourceCollectionOptions` structure.
         /// - Parameters:
-        ///   - resourceComplexObject: External Resource as a ResourceCollection to put
         ///   - clientRequestId: A client-generated, opaque value with 1KB character limit that is recorded in analytics logs.
         ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
         ///   - dispatchQueue: A dispatch queue on which to call the completion handler. Defaults to `DispatchQueue.main`.
         public init(
-            resourceComplexObject: ResourceCollection? = nil,
             clientRequestId: String? = nil,
             cancellationToken: CancellationToken? = nil,
             dispatchQueue: DispatchQueue? = nil
         ) {
-            self.resourceComplexObject = resourceComplexObject
             self.clientRequestId = clientRequestId
             self.cancellationToken = cancellationToken
             self.dispatchQueue = dispatchQueue

--- a/test/integration/generated/model-flattening/Source/Options/AutoRestResourceFlatteningTestService+PutSimpleProductOptions.swift
+++ b/test/integration/generated/model-flattening/Source/Options/AutoRestResourceFlatteningTestService+PutSimpleProductOptions.swift
@@ -18,9 +18,6 @@ import Foundation
 extension AutoRestResourceFlatteningTestService {
     /// User-configurable options for the `AutoRestResourceFlatteningTestService.PutSimpleProduct` operation.
     public struct PutSimpleProductOptions: RequestOptions {
-        /// Simple body product to put
-        public let simpleBodyProduct: SimpleProduct?
-
         /// A client-generated, opaque value with 1KB character limit that is recorded in analytics logs.
         /// Highly recommended for correlating client-side activites with requests received by the server.
         public let clientRequestId: String?
@@ -33,17 +30,14 @@ extension AutoRestResourceFlatteningTestService {
 
         /// Initialize a `PutSimpleProductOptions` structure.
         /// - Parameters:
-        ///   - simpleBodyProduct: Simple body product to put
         ///   - clientRequestId: A client-generated, opaque value with 1KB character limit that is recorded in analytics logs.
         ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
         ///   - dispatchQueue: A dispatch queue on which to call the completion handler. Defaults to `DispatchQueue.main`.
         public init(
-            simpleBodyProduct: SimpleProduct? = nil,
             clientRequestId: String? = nil,
             cancellationToken: CancellationToken? = nil,
             dispatchQueue: DispatchQueue? = nil
         ) {
-            self.simpleBodyProduct = simpleBodyProduct
             self.clientRequestId = clientRequestId
             self.cancellationToken = cancellationToken
             self.dispatchQueue = dispatchQueue

--- a/test/integration/generated/model-flattening/Source/Options/AutoRestResourceFlatteningTestService+PutWrappedArrayOptions.swift
+++ b/test/integration/generated/model-flattening/Source/Options/AutoRestResourceFlatteningTestService+PutWrappedArrayOptions.swift
@@ -18,9 +18,6 @@ import Foundation
 extension AutoRestResourceFlatteningTestService {
     /// User-configurable options for the `AutoRestResourceFlatteningTestService.PutWrappedArray` operation.
     public struct PutWrappedArrayOptions: RequestOptions {
-        /// External Resource as an Array to put
-        public let resourceArray: [WrappedProduct]?
-
         /// A client-generated, opaque value with 1KB character limit that is recorded in analytics logs.
         /// Highly recommended for correlating client-side activites with requests received by the server.
         public let clientRequestId: String?
@@ -33,17 +30,14 @@ extension AutoRestResourceFlatteningTestService {
 
         /// Initialize a `PutWrappedArrayOptions` structure.
         /// - Parameters:
-        ///   - resourceArray: External Resource as an Array to put
         ///   - clientRequestId: A client-generated, opaque value with 1KB character limit that is recorded in analytics logs.
         ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
         ///   - dispatchQueue: A dispatch queue on which to call the completion handler. Defaults to `DispatchQueue.main`.
         public init(
-            resourceArray: [WrappedProduct]? = nil,
             clientRequestId: String? = nil,
             cancellationToken: CancellationToken? = nil,
             dispatchQueue: DispatchQueue? = nil
         ) {
-            self.resourceArray = resourceArray
             self.clientRequestId = clientRequestId
             self.cancellationToken = cancellationToken
             self.dispatchQueue = dispatchQueue

--- a/test/integration/generated/xms-error-responses/Source/Models/PetActionError.swift
+++ b/test/integration/generated/xms-error-responses/Source/Models/PetActionError.swift
@@ -21,6 +21,8 @@ public struct PetActionError: Codable, Swift.Error {
     public let errorType: String
     /// the error message
     public let errorMessage: String?
+    /// action feedback
+    public let actionResponse: String?
 
     // MARK: Initializers
 
@@ -28,11 +30,13 @@ public struct PetActionError: Codable, Swift.Error {
     /// - Parameters:
     ///   - errorType:
     ///   - errorMessage: the error message
+    ///   - actionResponse: action feedback
     public init(
-        errorType: String, errorMessage: String? = nil
+        errorType: String, errorMessage: String? = nil, actionResponse: String? = nil
     ) {
         self.errorType = errorType
         self.errorMessage = errorMessage
+        self.actionResponse = actionResponse
     }
 
     // MARK: Codable
@@ -40,6 +44,7 @@ public struct PetActionError: Codable, Swift.Error {
     enum CodingKeys: String, CodingKey {
         case errorType
         case errorMessage
+        case actionResponse
     }
 
     /// Initialize a `PetActionError` structure from decoder
@@ -47,6 +52,7 @@ public struct PetActionError: Codable, Swift.Error {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.errorType = try container.decode(String.self, forKey: .errorType)
         self.errorMessage = try? container.decode(String.self, forKey: .errorMessage)
+        self.actionResponse = try? container.decode(String.self, forKey: .actionResponse)
     }
 
     /// Encode a `PetActionError` structure
@@ -54,5 +60,6 @@ public struct PetActionError: Codable, Swift.Error {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(errorType, forKey: .errorType)
         if errorMessage != nil { try? container.encode(errorMessage, forKey: .errorMessage) }
+        if actionResponse != nil { try? container.encode(actionResponse, forKey: .actionResponse) }
     }
 }

--- a/test/integration/generated/xms-error-responses/Source/Models/PetHungryOrThirstyError.swift
+++ b/test/integration/generated/xms-error-responses/Source/Models/PetHungryOrThirstyError.swift
@@ -15,7 +15,7 @@ import Foundation
 // swiftlint:disable line_length
 // swiftlint:disable cyclomatic_complexity
 
-public struct PetHungryOrThirstyError: Codable, Swift.Error {
+public struct PetHungryOrThirstyError: Codable {
     // MARK: Properties
 
     /// is the pet hungry or thirsty or both
@@ -26,6 +26,8 @@ public struct PetHungryOrThirstyError: Codable, Swift.Error {
     public let errorType: String
     /// the error message
     public let errorMessage: String?
+    /// action feedback
+    public let actionResponse: String?
 
     // MARK: Initializers
 
@@ -35,13 +37,16 @@ public struct PetHungryOrThirstyError: Codable, Swift.Error {
     ///   - reason: why is the pet sad
     ///   - errorType:
     ///   - errorMessage: the error message
+    ///   - actionResponse: action feedback
     public init(
-        hungryOrThirsty: String? = nil, reason: String? = nil, errorType: String, errorMessage: String? = nil
+        hungryOrThirsty: String? = nil, reason: String? = nil, errorType: String, errorMessage: String? = nil,
+        actionResponse: String? = nil
     ) {
         self.hungryOrThirsty = hungryOrThirsty
         self.reason = reason
         self.errorType = errorType
         self.errorMessage = errorMessage
+        self.actionResponse = actionResponse
     }
 
     // MARK: Codable
@@ -51,6 +56,7 @@ public struct PetHungryOrThirstyError: Codable, Swift.Error {
         case reason
         case errorType
         case errorMessage
+        case actionResponse
     }
 
     /// Initialize a `PetHungryOrThirstyError` structure from decoder
@@ -60,6 +66,7 @@ public struct PetHungryOrThirstyError: Codable, Swift.Error {
         self.reason = try? container.decode(String.self, forKey: .reason)
         self.errorType = try container.decode(String.self, forKey: .errorType)
         self.errorMessage = try? container.decode(String.self, forKey: .errorMessage)
+        self.actionResponse = try? container.decode(String.self, forKey: .actionResponse)
     }
 
     /// Encode a `PetHungryOrThirstyError` structure
@@ -69,5 +76,6 @@ public struct PetHungryOrThirstyError: Codable, Swift.Error {
         if reason != nil { try? container.encode(reason, forKey: .reason) }
         try container.encode(errorType, forKey: .errorType)
         if errorMessage != nil { try? container.encode(errorMessage, forKey: .errorMessage) }
+        if actionResponse != nil { try? container.encode(actionResponse, forKey: .actionResponse) }
     }
 }

--- a/test/integration/generated/xms-error-responses/Source/Models/PetSadError.swift
+++ b/test/integration/generated/xms-error-responses/Source/Models/PetSadError.swift
@@ -15,7 +15,7 @@ import Foundation
 // swiftlint:disable line_length
 // swiftlint:disable cyclomatic_complexity
 
-public struct PetSadError: Codable, Swift.Error {
+public struct PetSadError: Codable {
     // MARK: Properties
 
     /// why is the pet sad
@@ -24,6 +24,8 @@ public struct PetSadError: Codable, Swift.Error {
     public let errorType: String
     /// the error message
     public let errorMessage: String?
+    /// action feedback
+    public let actionResponse: String?
 
     // MARK: Initializers
 
@@ -32,12 +34,14 @@ public struct PetSadError: Codable, Swift.Error {
     ///   - reason: why is the pet sad
     ///   - errorType:
     ///   - errorMessage: the error message
+    ///   - actionResponse: action feedback
     public init(
-        reason: String? = nil, errorType: String, errorMessage: String? = nil
+        reason: String? = nil, errorType: String, errorMessage: String? = nil, actionResponse: String? = nil
     ) {
         self.reason = reason
         self.errorType = errorType
         self.errorMessage = errorMessage
+        self.actionResponse = actionResponse
     }
 
     // MARK: Codable
@@ -46,6 +50,7 @@ public struct PetSadError: Codable, Swift.Error {
         case reason
         case errorType
         case errorMessage
+        case actionResponse
     }
 
     /// Initialize a `PetSadError` structure from decoder
@@ -54,6 +59,7 @@ public struct PetSadError: Codable, Swift.Error {
         self.reason = try? container.decode(String.self, forKey: .reason)
         self.errorType = try container.decode(String.self, forKey: .errorType)
         self.errorMessage = try? container.decode(String.self, forKey: .errorMessage)
+        self.actionResponse = try? container.decode(String.self, forKey: .actionResponse)
     }
 
     /// Encode a `PetSadError` structure
@@ -62,5 +68,6 @@ public struct PetSadError: Codable, Swift.Error {
         if reason != nil { try? container.encode(reason, forKey: .reason) }
         try container.encode(errorType, forKey: .errorType)
         if errorMessage != nil { try? container.encode(errorMessage, forKey: .errorMessage) }
+        if actionResponse != nil { try? container.encode(actionResponse, forKey: .actionResponse) }
     }
 }


### PR DESCRIPTION
* Fix handing of byteArray in response body
* Fix missing signature parameters from request parameters
* Fix `path` when virtual params is from flatten group object
* Add 10 test cases for body-string string operation
* Remove body parameters from option struct
* Remove default value '=nil' in required and nullable parameter