### PR TITLE
skip adding endpoint and api-version to list of the global parameters

### DIFF
--- a/src/AutorestSwift/View Models/ServiceClientFileViewModel.swift
+++ b/src/AutorestSwift/View Models/ServiceClientFileViewModel.swift
@@ -79,7 +79,8 @@ func resolveGlobalParameters(from model: CodeModel) -> ([ParameterViewModel], St
     for globalParameter in model.globalParameters ?? [] {
         if globalParameter.name == "$host" {
             host = globalParameter.value.clientDefaultValue
-        } else {
+            // `endpoint` and `api-version` have different logic in generated code. Do not add them to the list of global parameters
+        } else if !["endpoint", "api-version"].contains(globalParameter.serializedName) {
             globalParameters.append(ParameterViewModel(from: globalParameter))
         }
     }


### PR DESCRIPTION
`endpoint` and `api-version` already have different logic in generated code. Do not add those to the 'global parameters' list.
