### PR TITLE
Add coverage report upload step to CI pipeline

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -17,4 +17,5 @@ jobs:
       - script: |
           npm run coverage-push -- $(Build.Repository.Name) $(Build.SourceBranch) $(github-token) $(storage-coverage-user) $(storage-coverage-pass)
         workingDirectory: node_modules/@microsoft.azure/autorest.testserver
+        condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))
         displayName: "Upload Coverage Report"

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -13,3 +13,8 @@ jobs:
 
       - script: npm run test
         displayName: Run Tests
+
+      - script: |
+          npm run coverage-push -- $(Build.Repository.Name) $(Build.SourceBranch) $(github-token) $(storage-coverage-user) $(storage-coverage-pass)
+        workingDirectory: node_modules/@microsoft.azure/autorest.testserver
+        displayName: "Upload Coverage Report"


### PR DESCRIPTION
This adds an extra step to the CI pipeline to push testserver coverage numbers to the AutoRest coverage dashboard.  I'll set up a private pipeline with the necessary variables to do this successfully when run on non PR builds on `master`.  I believe the step still passes if the credentials aren't available.