### PR TITLE
Upgrade modelerfour to 4.15.442 to resolve error generating Chat SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Please don't edit this section unless you're re-configuring how the Swift extens
 
 version: 3.0.6267
 use-extension:
-  "@autorest/modelerfour": "4.15.410"
+  "@autorest/modelerfour": "4.15.442"
 
 modelerfour:
   # this runs a pre-namer step to clean up names


### PR DESCRIPTION
Using the latest Chat swagger we encounter the following error running autorest.swift: 

```
FATAL: Error: Circular $ref in Model -- #/components/schemas/schemas:34 :: ["#/components/schemas/schemas:34"]
  Error: Plugin prechecker reported failure.
```

This has been resolved in modelerfour 4.15.442 https://github.com/Azure/autorest/issues/3630
I've confirmed when I upgrade locally the error goes away.
