### PR TITLE
Fix issues with AutoRest Jazzy generation

### DIFF
--- a/src/AutorestSwift/Code Generator/FileDestination.swift
+++ b/src/AutorestSwift/Code Generator/FileDestination.swift
@@ -60,7 +60,7 @@ enum FileDestination {
             return baseUrl.appendingPathComponent("Source").appendingPathComponent("Generated")
                 .appendingPathComponent("Util")
         case .jazzy:
-            return baseUrl.appendingPathComponent(".jazzy")
+            return baseUrl.appendingPathComponent("jazzy")
         }
     }
 }

--- a/templates/Jazzy_File.stencil
+++ b/templates/Jazzy_File.stencil
@@ -10,7 +10,6 @@ output: ../build/jazzy/{{ model.name }}
 swift_build_tool: spm
 clean: true
 sdk: iphonesimulator
-sdk: iphonesimulator
 xcodebuild_arguments:
   - "-workspace"
   - "AzureSDK.xcworkspace"

--- a/templates/Jazzy_File.stencil
+++ b/templates/Jazzy_File.stencil
@@ -10,12 +10,16 @@ output: ../build/jazzy/{{ model.name }}
 swift_build_tool: spm
 clean: true
 sdk: iphonesimulator
-swift_build_tool: spm
-build_tool_arguments:
-  - "-Xswiftc"
-  - "-swift-version"
-  - "-Xswiftc"
-  - "5"
+sdk: iphonesimulator
+xcodebuild_arguments:
+  - "-workspace"
+  - "AzureSDK.xcworkspace"
+  - "-scheme"
+  - "{{ model.name }}"
+  - "-sdk"
+  - "iphonesimulator"
+  - "-arch"
+  - "x86_64"
 exclude:
   - "*/Source/ObjectiveCCompatibility/*"
   - "*/Tests/*"


### PR DESCRIPTION
- uses xcodebuild instead of `swift build` since the latter only works on macOS.
- generated jazzy files in the `jazzy` folder instead of `.jazzy`.