### PR TITLE
Ensure property visibility is consistent with containing class visibility.

### DIFF
--- a/.swiftpm/xcode/xcuserdata/travisprescott.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/.swiftpm/xcode/xcuserdata/travisprescott.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -9,19 +9,24 @@
 			<key>orderHint</key>
 			<integer>0</integer>
 		</dict>
+		<key>AutorestSwiftTest.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>7</integer>
+		</dict>
 		<key>SWXMLHashPlayground (Playground) 1.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>6</integer>
+			<integer>5</integer>
 		</dict>
 		<key>SWXMLHashPlayground (Playground) 2.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>7</integer>
+			<integer>6</integer>
 		</dict>
 		<key>SWXMLHashPlayground (Playground) 3.xcscheme</key>
 		<dict>
@@ -49,21 +54,21 @@
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>5</integer>
+			<integer>4</integer>
 		</dict>
 		<key>Spectre (Playground) 1.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>3</integer>
+			<integer>2</integer>
 		</dict>
 		<key>Spectre (Playground) 2.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>4</integer>
+			<integer>3</integer>
 		</dict>
 		<key>Spectre (Playground) 3.xcscheme</key>
 		<dict>
@@ -91,7 +96,7 @@
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>1</integer>
 		</dict>
 		<key>autorest.swift.xcscheme_^#shared#^_</key>
 		<dict>
@@ -123,6 +128,11 @@
 	<key>SuppressBuildableAutocreation</key>
 	<dict>
 		<key>AutorestSwift</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>AutorestSwiftTest</key>
 		<dict>
 			<key>primary</key>
 			<true/>

--- a/AutorestSwiftTest/AutoRestValidationTest.swift
+++ b/AutorestSwiftTest/AutoRestValidationTest.swift
@@ -30,7 +30,7 @@ import XCTest
 
 // swiftlint:disable force_try
 class AutoRestValidationTest: XCTestCase {
-    private func getClient(apiVersion: AutoRestValidationTestClient.ApiVersion? = nil) -> AutoRestValidationTestClient {
+    private func getClient(apiVersion: AutoRestValidationTestClientOptions.ApiVersion? = nil) -> AutoRestValidationTestClient {
         let options = AutoRestValidationTestClientOptions(apiVersion: apiVersion ?? .custom("12-34-5678"))
         return try! AutoRestValidationTestClient(
             subscriptionId: "abc123", url: URL(string: "http://localhost:3000")!,

--- a/scripts/swagger_info.json
+++ b/scripts/swagger_info.json
@@ -1,6 +1,6 @@
 [
     {
-        "path": "specification/communication/data-plane/Microsoft.CommunicationServicesChat/preview/2020-09-21-preview2/communicationserviceschat.json",
+        "path": "specification/communication/data-plane/Chat/stable/2021-03-07/communicationserviceschat.json",
         "namespace": "communication",
         "name": "AzureCommunciationChat"
     }

--- a/src/AutorestSwift/Code Generator/CommandLineArguments.swift
+++ b/src/AutorestSwift/Code Generator/CommandLineArguments.swift
@@ -246,6 +246,16 @@ internal struct ModelMap {
             return name
         }
     }
+
+    /// Returns the alias for a given name or nil if no alias is present
+    internal func alias(for name: String) -> String? {
+        return map[name]
+    }
+
+    /// Returns the name for a given alias or nil if no name is present
+    internal func name(for alias: String) -> String? {
+        return reverseMap[alias]
+    }
 }
 
 private func split(string val: String?) -> [String]? {

--- a/src/AutorestSwift/Code Generator/SwiftGenerator.swift
+++ b/src/AutorestSwift/Code Generator/SwiftGenerator.swift
@@ -179,11 +179,12 @@ class SwiftGenerator: CodeGenerator {
         }
 
         // Create ClientOptions.swift file
+        let optionsFileViewModel = ClientOptionsFileViewModel(from: model)
         try render(
             template: "Client_Options_File",
             toSubfolder: .options,
-            withFilename: "\(clientViewModel.name)Options",
-            andParams: ["model": clientViewModel]
+            withFilename: optionsFileViewModel.name,
+            andParams: ["model": optionsFileViewModel]
         )
 
         if !exists(filename: "README.md", inSubfolder: .root) {

--- a/src/AutorestSwift/Models/Complex/NumberSchema.swift
+++ b/src/AutorestSwift/Models/Complex/NumberSchema.swift
@@ -83,7 +83,7 @@ class NumberSchema: PrimitiveSchema {
         try super.encode(to: encoder)
     }
 
-    override func swiftType(parentName: String? = nil) -> String {
+    override func swiftType(parentName _: String? = nil) -> String {
         var swiftType: String
         switch precision {
         case 32:

--- a/src/AutorestSwift/Models/Complex/NumberSchema.swift
+++ b/src/AutorestSwift/Models/Complex/NumberSchema.swift
@@ -83,7 +83,7 @@ class NumberSchema: PrimitiveSchema {
         try super.encode(to: encoder)
     }
 
-    override func swiftType(optional: Bool = false) -> String {
+    override func swiftType(parentName: String? = nil) -> String {
         var swiftType: String
         switch precision {
         case 32:
@@ -95,6 +95,6 @@ class NumberSchema: PrimitiveSchema {
         default:
             swiftType = (type == .integer) ? "Int" : "Double"
         }
-        return optional ? "\(swiftType)?" : swiftType
+        return swiftType
     }
 }

--- a/src/AutorestSwift/View Models/ClientOptionsFileViewModel.swift
+++ b/src/AutorestSwift/View Models/ClientOptionsFileViewModel.swift
@@ -29,12 +29,20 @@ import Foundation
 /// View Model for the service client file.
 struct ClientOptionsFileViewModel {
     let name: String
-    let clientName: String
+    let packageName: String
     let visibility: String
+    let apiVersion: String
+    let apiVersionName: String
 
     init(from model: CodeModel) {
-        self.name = "\(model.packageName)ClientOptions"
-        self.clientName = Manager.shared.args!.generateAsInternal.aliasOrName(for: "\(model.packageName)Client")
+        let baseName = "\(model.packageName)Client"
+        self.name = Manager.shared.args!.generateAsInternal.aliasOrName(for: "\(baseName)Options")
+        self.packageName = model.packageName
         self.visibility = Manager.shared.args!.generateAsInternal.visibility(for: name)
+        self.apiVersion = model.getApiVersion()
+        /// Swift enums should contain only alphanumeric characters.
+        self
+            .apiVersionName =
+            "v\(apiVersion.replacingOccurrences(of: "-", with: "").replacingOccurrences(of: ".", with: ""))"
     }
 }

--- a/src/AutorestSwift/View Models/ClientOptionsFileViewModel.swift
+++ b/src/AutorestSwift/View Models/ClientOptionsFileViewModel.swift
@@ -1,0 +1,40 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+/// View Model for the service client file.
+struct ClientOptionsFileViewModel {
+    let name: String
+    let clientName: String
+    let visibility: String
+
+    init(from model: CodeModel) {
+        self.name = "\(model.packageName)ClientOptions"
+        self.clientName = Manager.shared.args!.generateAsInternal.aliasOrName(for: "\(model.packageName)Client")
+        self.visibility = Manager.shared.args!.generateAsInternal.visibility(for: name)
+    }
+}

--- a/src/AutorestSwift/View Models/ObjectViewModel.swift
+++ b/src/AutorestSwift/View Models/ObjectViewModel.swift
@@ -54,7 +54,8 @@ struct ObjectViewModel {
             if property.schema as? ConstantSchema != nil {
                 consts.append(ConstantViewModel(from: property))
             } else {
-                props.append(PropertyViewModel(from: property))
+                // properties should inherit the visibility of their parent
+                props.append(PropertyViewModel(from: property, parentName: self.name))
             }
         }
         self.properties = props

--- a/src/AutorestSwift/View Models/ObjectViewModel.swift
+++ b/src/AutorestSwift/View Models/ObjectViewModel.swift
@@ -55,7 +55,7 @@ struct ObjectViewModel {
                 consts.append(ConstantViewModel(from: property))
             } else {
                 // properties should inherit the visibility of their parent
-                props.append(PropertyViewModel(from: property, parentName: self.name))
+                props.append(PropertyViewModel(from: property, parentName: name))
             }
         }
         self.properties = props

--- a/src/AutorestSwift/View Models/ParameterViewModel.swift
+++ b/src/AutorestSwift/View Models/ParameterViewModel.swift
@@ -101,11 +101,12 @@ struct ParameterViewModel {
 
     init(from param: ParameterType, with operation: Operation? = nil) {
         let optional = !param.required
+        let swiftType = param.schema.swiftType()
         self.init(
             name: param.variableName,
             serializedName: param.serializedName ?? param.name,
             pathOrValue: "",
-            type: param.schema.swiftType(optional: optional),
+            type: optional ? "\(swiftType)?" : swiftType,
             optional: optional,
             defaultValue: ViewModelDefault(from: param.clientDefaultValue, isString: true, isOptional: optional),
             comment: ViewModelComment(from: param.description),

--- a/src/AutorestSwift/View Models/PropertyViewModel.swift
+++ b/src/AutorestSwift/View Models/PropertyViewModel.swift
@@ -64,26 +64,26 @@ struct PropertyViewModel {
     }
 
     /// Initialize from Value type (such as Property or Parameter)
-    init(from schema: Value) {
+    init(from schema: Value, parentName: String? = nil) {
         // The `name` field is preferred.
         let name = schema.name
         assert(!name.isEmpty)
         self.name = name
         self.serializedName = schema.serializedName ?? name
         self.comment = ViewModelComment(from: schema.description)
-        self.className = schema.schema!.swiftType()
+        self.className = schema.schema!.swiftType(parentName: parentName)
         self.optional = !schema.required
         self.type = optional ? "\(className)?" : className
         self.defaultValue = ViewModelDefault(from: schema.clientDefaultValue, isString: true, isOptional: optional)
         self.initDefaultValue = optional ? "= nil" : ""
     }
 
-    init(from schema: PropertyType) {
+    init(from schema: PropertyType, parentName: String? = nil) {
         switch schema {
         case let .regular(reg):
-            self.init(from: reg)
+            self.init(from: reg, parentName: parentName)
         case let .grouped(group):
-            self.init(from: group)
+            self.init(from: group, parentName: parentName)
         }
     }
 }

--- a/src/AutorestSwift/View Models/ServiceClientFileViewModel.swift
+++ b/src/AutorestSwift/View Models/ServiceClientFileViewModel.swift
@@ -32,8 +32,7 @@ struct ServiceClientFileViewModel {
     let comment: ViewModelComment
     let visibility: String
     let operationGroups: [OperationGroupViewModel]
-    let apiVersion: String
-    let apiVersionName: String
+    let optionsName: String
     let protocols: String
     let paging: Language.PagingNames?
     let globalParameters: [ParameterViewModel]
@@ -44,8 +43,9 @@ struct ServiceClientFileViewModel {
     let host: String
 
     init(from model: CodeModel) {
-        let name = "\(model.packageName)Client"
-        self.name = Manager.shared.args!.generateAsInternal.aliasOrName(for: name)
+        let baseName = "\(model.packageName)Client"
+        self.optionsName = Manager.shared.args!.generateAsInternal.aliasOrName(for: "\(baseName)Options")
+        self.name = Manager.shared.args!.generateAsInternal.aliasOrName(for: baseName)
         self.visibility = Manager.shared.args!.generateAsInternal.visibility(for: name)
         self.comment = ViewModelComment(from: model.description)
         var operationGroups = [OperationGroupViewModel]()
@@ -61,11 +61,7 @@ struct ServiceClientFileViewModel {
         }
         self.operationGroups = operationGroups
         self.namedOperationGroups = namedOperationGroups
-        self.apiVersion = model.getApiVersion()
-        /// Swift enums should contain only alphanumeric characters.
-        self
-            .apiVersionName =
-            "v\(apiVersion.replacingOccurrences(of: "-", with: "").replacingOccurrences(of: ".", with: ""))"
+
         self.paging = model.pagingNames
         self.protocols = paging != nil ? "PipelineClient, PageableClient" : "PipelineClient"
 

--- a/src/AutorestSwift/View Models/VirtualParam.swift
+++ b/src/AutorestSwift/View Models/VirtualParam.swift
@@ -39,7 +39,9 @@ struct VirtualParam {
             path = "\(groupBy).\(path)"
         }
         self.path = path
-        self.type = param.schema!.swiftType(optional: !param.required)
+        let optional = !param.required
+        let swiftType = param.schema!.swiftType()
+        self.type = optional ? "\(swiftType)?" : swiftType
         self.defaultValue = param.required ? "" : " = nil"
     }
 }

--- a/templates/Client_File.stencil
+++ b/templates/Client_File.stencil
@@ -16,10 +16,8 @@
     }
 {% endif %}
 
-    {% include "Client_ApiVersion_Snippet.stencil" model %}
-
     /// Options provided to configure this `{{ model.name }}`.
-    {{ model.visibility }} let options: {{ model.name }}Options
+    {{ model.visibility }} let options: {{ model.optionsName }}
 
     // MARK: Initializers
     /// Create a {{ model.name }} client.
@@ -39,7 +37,7 @@
         endpoint: URL,
     {% endif %}
         authPolicy: Authenticating,
-        withOptions options: {{ model.name }}Options
+        withOptions options: {{ model.optionsName }}
     ) throws {
     {% if model.host != "" %}
         let defaultHost = URL(string: {{ model.host }})

--- a/templates/Client_Options_File.stencil
+++ b/templates/Client_Options_File.stencil
@@ -5,29 +5,29 @@
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `{{ model.name }}`.
-{{ model.visibility }} struct {{ model.name }}Options: ClientOptions {
-    /// The API version of the {{ model.description }} to invoke.
+/// User-configurable options for the `{{ model.clientName }}`.
+{{ model.visibility }} struct {{ model.name }}: ClientOptions {
+    /// The API version of the {{ model.clientName }} to invoke.
     {{ model.visibility }} let apiVersion: String
-    /// The `ClientLogger` to be used by this `{{ model.name }}`.
+    /// The `ClientLogger` to be used by this `{{ model.clientName }}`.
     {{ model.visibility }} let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `{{ model.name }}`.
+    /// Options for configuring telemetry sent by this `{{ model.clientName }}`.
     {{ model.visibility }} let telemetryOptions: TelemetryOptions
     /// Global transport options
     {{ model.visibility }} let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     {{ model.visibility }} let dispatchQueue: DispatchQueue?
 
-    /// Initialize a `{{ model.name }}Options` structure.
+    /// Initialize a `{{ model.name }}` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the {{ model.description }} to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `{{ model.name }}`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `{{ model.name }}`.
+    ///   - apiVersion: The API version of the {{ model.clientName }} to invoke.
+    ///   - logger: The `ClientLogger` to be used by this `{{ model.clientName }}`.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this `{{ model.clientName }}`.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     {{ model.visibility }} init(
-        apiVersion: {{ model.name }}.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "{{ model.name }}Client"),
+        apiVersion: {{ model.clientName }}.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "{{ model.clientName }}"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/templates/Client_Options_File.stencil
+++ b/templates/Client_Options_File.stencil
@@ -5,29 +5,31 @@
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `{{ model.clientName }}`.
+/// User-configurable client options.
 {{ model.visibility }} struct {{ model.name }}: ClientOptions {
-    /// The API version of the {{ model.clientName }} to invoke.
+    /// The API version of the client to invoke.
     {{ model.visibility }} let apiVersion: String
-    /// The `ClientLogger` to be used by this `{{ model.clientName }}`.
+    /// The `ClientLogger` to be used by this client.
     {{ model.visibility }} let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `{{ model.clientName }}`.
+    /// Options for configuring telemetry sent by this client.
     {{ model.visibility }} let telemetryOptions: TelemetryOptions
     /// Global transport options
     {{ model.visibility }} let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     {{ model.visibility }} let dispatchQueue: DispatchQueue?
 
+    {% include "Client_ApiVersion_Snippet.stencil" model %}
+
     /// Initialize a `{{ model.name }}` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the {{ model.clientName }} to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `{{ model.clientName }}`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `{{ model.clientName }}`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     {{ model.visibility }} init(
-        apiVersion: {{ model.clientName }}.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "{{ model.clientName }}"),
+        apiVersion: {{ model.name }}.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "{{ model.packageName }}"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/body-array/Source/Generated/AutoRestSwaggerBatArrayClient.swift
+++ b/test/integration/generated/body-array/Source/Generated/AutoRestSwaggerBatArrayClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestSwaggerBatArrayClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestSwaggerBatArrayClient`.
     public let options: AutoRestSwaggerBatArrayClientOptions
 

--- a/test/integration/generated/body-array/Source/Generated/Options/AutoRestSwaggerBatArrayClientOptions.swift
+++ b/test/integration/generated/body-array/Source/Generated/Options/AutoRestSwaggerBatArrayClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestSwaggerBatArrayClient`.
+/// User-configurable client options.
 public struct AutoRestSwaggerBatArrayClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestSwaggerBatArrayClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestSwaggerBatArrayClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestSwaggerBatArrayClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestSwaggerBatArrayClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestSwaggerBatArrayClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestSwaggerBatArrayClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestSwaggerBatArrayClientClient"),
+        apiVersion: AutoRestSwaggerBatArrayClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestSwaggerBatArray"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/body-boolean/Source/Generated/AutoRestBoolTestClient.swift
+++ b/test/integration/generated/body-boolean/Source/Generated/AutoRestBoolTestClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestBoolTestClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestBoolTestClient`.
     public let options: AutoRestBoolTestClientOptions
 

--- a/test/integration/generated/body-boolean/Source/Generated/Options/AutoRestBoolTestClientOptions.swift
+++ b/test/integration/generated/body-boolean/Source/Generated/Options/AutoRestBoolTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestBoolTestClient`.
+/// User-configurable client options.
 public struct AutoRestBoolTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestBoolTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestBoolTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestBoolTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestBoolTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestBoolTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestBoolTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestBoolTestClientClient"),
+        apiVersion: AutoRestBoolTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestBoolTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/body-byte/Source/Generated/AutoRestSwaggerBatByteClient.swift
+++ b/test/integration/generated/body-byte/Source/Generated/AutoRestSwaggerBatByteClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestSwaggerBatByteClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestSwaggerBatByteClient`.
     public let options: AutoRestSwaggerBatByteClientOptions
 

--- a/test/integration/generated/body-byte/Source/Generated/Options/AutoRestSwaggerBatByteClientOptions.swift
+++ b/test/integration/generated/body-byte/Source/Generated/Options/AutoRestSwaggerBatByteClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestSwaggerBatByteClient`.
+/// User-configurable client options.
 public struct AutoRestSwaggerBatByteClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestSwaggerBatByteClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestSwaggerBatByteClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestSwaggerBatByteClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestSwaggerBatByteClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestSwaggerBatByteClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestSwaggerBatByteClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestSwaggerBatByteClientClient"),
+        apiVersion: AutoRestSwaggerBatByteClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestSwaggerBatByte"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/body-date/Source/Generated/AutoRestDateTestClient.swift
+++ b/test/integration/generated/body-date/Source/Generated/AutoRestDateTestClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestDateTestClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestDateTestClient`.
     public let options: AutoRestDateTestClientOptions
 

--- a/test/integration/generated/body-date/Source/Generated/Options/AutoRestDateTestClientOptions.swift
+++ b/test/integration/generated/body-date/Source/Generated/Options/AutoRestDateTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestDateTestClient`.
+/// User-configurable client options.
 public struct AutoRestDateTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestDateTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestDateTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestDateTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestDateTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestDateTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestDateTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestDateTestClientClient"),
+        apiVersion: AutoRestDateTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestDateTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/body-datetime-rfc1123/Source/Generated/AutoRestRfC1123DateTimeTestClient.swift
+++ b/test/integration/generated/body-datetime-rfc1123/Source/Generated/AutoRestRfC1123DateTimeTestClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestRfC1123DateTimeTestClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestRfC1123DateTimeTestClient`.
     public let options: AutoRestRfC1123DateTimeTestClientOptions
 

--- a/test/integration/generated/body-datetime-rfc1123/Source/Generated/Options/AutoRestRfC1123DateTimeTestClientOptions.swift
+++ b/test/integration/generated/body-datetime-rfc1123/Source/Generated/Options/AutoRestRfC1123DateTimeTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestRfC1123DateTimeTestClient`.
+/// User-configurable client options.
 public struct AutoRestRfC1123DateTimeTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestRfC1123DateTimeTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestRfC1123DateTimeTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestRfC1123DateTimeTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestRfC1123DateTimeTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestRfC1123DateTimeTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestRfC1123DateTimeTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestRfC1123DateTimeTestClientClient"),
+        apiVersion: AutoRestRfC1123DateTimeTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestRfC1123DateTimeTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/body-datetime/Source/Generated/AutoRestDateTimeTestClient.swift
+++ b/test/integration/generated/body-datetime/Source/Generated/AutoRestDateTimeTestClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestDateTimeTestClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestDateTimeTestClient`.
     public let options: AutoRestDateTimeTestClientOptions
 

--- a/test/integration/generated/body-datetime/Source/Generated/Options/AutoRestDateTimeTestClientOptions.swift
+++ b/test/integration/generated/body-datetime/Source/Generated/Options/AutoRestDateTimeTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestDateTimeTestClient`.
+/// User-configurable client options.
 public struct AutoRestDateTimeTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestDateTimeTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestDateTimeTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestDateTimeTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestDateTimeTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestDateTimeTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestDateTimeTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestDateTimeTestClientClient"),
+        apiVersion: AutoRestDateTimeTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestDateTimeTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/body-dictionary/Source/Generated/AutoRestSwaggerBatDictionaryClient.swift
+++ b/test/integration/generated/body-dictionary/Source/Generated/AutoRestSwaggerBatDictionaryClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestSwaggerBatDictionaryClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestSwaggerBatDictionaryClient`.
     public let options: AutoRestSwaggerBatDictionaryClientOptions
 

--- a/test/integration/generated/body-dictionary/Source/Generated/Options/AutoRestSwaggerBatDictionaryClientOptions.swift
+++ b/test/integration/generated/body-dictionary/Source/Generated/Options/AutoRestSwaggerBatDictionaryClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestSwaggerBatDictionaryClient`.
+/// User-configurable client options.
 public struct AutoRestSwaggerBatDictionaryClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestSwaggerBatDictionaryClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestSwaggerBatDictionaryClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestSwaggerBatDictionaryClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestSwaggerBatDictionaryClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestSwaggerBatDictionaryClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestSwaggerBatDictionaryClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestSwaggerBatDictionaryClientClient"),
+        apiVersion: AutoRestSwaggerBatDictionaryClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestSwaggerBatDictionary"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/body-duration/Source/Generated/AutoRestDurationTestClient.swift
+++ b/test/integration/generated/body-duration/Source/Generated/AutoRestDurationTestClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestDurationTestClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestDurationTestClient`.
     public let options: AutoRestDurationTestClientOptions
 

--- a/test/integration/generated/body-duration/Source/Generated/Options/AutoRestDurationTestClientOptions.swift
+++ b/test/integration/generated/body-duration/Source/Generated/Options/AutoRestDurationTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestDurationTestClient`.
+/// User-configurable client options.
 public struct AutoRestDurationTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestDurationTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestDurationTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestDurationTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestDurationTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestDurationTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestDurationTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestDurationTestClientClient"),
+        apiVersion: AutoRestDurationTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestDurationTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/body-file/Source/Generated/AutoRestSwaggerBatFileClient.swift
+++ b/test/integration/generated/body-file/Source/Generated/AutoRestSwaggerBatFileClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestSwaggerBatFileClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestSwaggerBatFileClient`.
     public let options: AutoRestSwaggerBatFileClientOptions
 

--- a/test/integration/generated/body-file/Source/Generated/Options/AutoRestSwaggerBatFileClientOptions.swift
+++ b/test/integration/generated/body-file/Source/Generated/Options/AutoRestSwaggerBatFileClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestSwaggerBatFileClient`.
+/// User-configurable client options.
 public struct AutoRestSwaggerBatFileClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestSwaggerBatFileClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestSwaggerBatFileClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestSwaggerBatFileClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestSwaggerBatFileClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestSwaggerBatFileClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestSwaggerBatFileClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestSwaggerBatFileClientClient"),
+        apiVersion: AutoRestSwaggerBatFileClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestSwaggerBatFile"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/body-integer/Source/Generated/AutoRestIntegerTestClient.swift
+++ b/test/integration/generated/body-integer/Source/Generated/AutoRestIntegerTestClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestIntegerTestClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestIntegerTestClient`.
     public let options: AutoRestIntegerTestClientOptions
 

--- a/test/integration/generated/body-integer/Source/Generated/Options/AutoRestIntegerTestClientOptions.swift
+++ b/test/integration/generated/body-integer/Source/Generated/Options/AutoRestIntegerTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestIntegerTestClient`.
+/// User-configurable client options.
 public struct AutoRestIntegerTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestIntegerTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestIntegerTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestIntegerTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestIntegerTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestIntegerTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestIntegerTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestIntegerTestClientClient"),
+        apiVersion: AutoRestIntegerTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestIntegerTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/body-number/Source/Generated/AutoRestNumberTestClient.swift
+++ b/test/integration/generated/body-number/Source/Generated/AutoRestNumberTestClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestNumberTestClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestNumberTestClient`.
     public let options: AutoRestNumberTestClientOptions
 

--- a/test/integration/generated/body-number/Source/Generated/Options/AutoRestNumberTestClientOptions.swift
+++ b/test/integration/generated/body-number/Source/Generated/Options/AutoRestNumberTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestNumberTestClient`.
+/// User-configurable client options.
 public struct AutoRestNumberTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestNumberTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestNumberTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestNumberTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestNumberTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestNumberTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestNumberTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestNumberTestClientClient"),
+        apiVersion: AutoRestNumberTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestNumberTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/body-string/Source/Generated/AutoRestSwaggerBatClient.swift
+++ b/test/integration/generated/body-string/Source/Generated/AutoRestSwaggerBatClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestSwaggerBatClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestSwaggerBatClient`.
     public let options: AutoRestSwaggerBatClientOptions
 

--- a/test/integration/generated/body-string/Source/Generated/Options/AutoRestSwaggerBatClientOptions.swift
+++ b/test/integration/generated/body-string/Source/Generated/Options/AutoRestSwaggerBatClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestSwaggerBatClient`.
+/// User-configurable client options.
 public struct AutoRestSwaggerBatClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestSwaggerBatClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestSwaggerBatClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestSwaggerBatClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestSwaggerBatClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestSwaggerBatClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestSwaggerBatClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestSwaggerBatClientClient"),
+        apiVersion: AutoRestSwaggerBatClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestSwaggerBat"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/body-time/Source/Generated/AutoRestTimeTestClient.swift
+++ b/test/integration/generated/body-time/Source/Generated/AutoRestTimeTestClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestTimeTestClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestTimeTestClient`.
     public let options: AutoRestTimeTestClientOptions
 

--- a/test/integration/generated/body-time/Source/Generated/Options/AutoRestTimeTestClientOptions.swift
+++ b/test/integration/generated/body-time/Source/Generated/Options/AutoRestTimeTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestTimeTestClient`.
+/// User-configurable client options.
 public struct AutoRestTimeTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestTimeTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestTimeTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestTimeTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestTimeTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestTimeTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestTimeTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestTimeTestClientClient"),
+        apiVersion: AutoRestTimeTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestTimeTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/custom-baseUrl-more-options/Source/Generated/AutoRestParameterizedCustomHostTestClient.swift
+++ b/test/integration/generated/custom-baseUrl-more-options/Source/Generated/AutoRestParameterizedCustomHostTestClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestParameterizedCustomHostTestClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestParameterizedCustomHostTestClient`.
     public let options: AutoRestParameterizedCustomHostTestClientOptions
 

--- a/test/integration/generated/custom-baseUrl-more-options/Source/Generated/Options/AutoRestParameterizedCustomHostTestClientOptions.swift
+++ b/test/integration/generated/custom-baseUrl-more-options/Source/Generated/Options/AutoRestParameterizedCustomHostTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestParameterizedCustomHostTestClient`.
+/// User-configurable client options.
 public struct AutoRestParameterizedCustomHostTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestParameterizedCustomHostTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestParameterizedCustomHostTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestParameterizedCustomHostTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestParameterizedCustomHostTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestParameterizedCustomHostTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestParameterizedCustomHostTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestParameterizedCustomHostTestClientClient"),
+        apiVersion: AutoRestParameterizedCustomHostTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestParameterizedCustomHostTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/custom-baseUrl/Source/Generated/AutoRestParameterizedHostTestClient.swift
+++ b/test/integration/generated/custom-baseUrl/Source/Generated/AutoRestParameterizedHostTestClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestParameterizedHostTestClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestParameterizedHostTestClient`.
     public let options: AutoRestParameterizedHostTestClientOptions
 

--- a/test/integration/generated/custom-baseUrl/Source/Generated/Options/AutoRestParameterizedHostTestClientOptions.swift
+++ b/test/integration/generated/custom-baseUrl/Source/Generated/Options/AutoRestParameterizedHostTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestParameterizedHostTestClient`.
+/// User-configurable client options.
 public struct AutoRestParameterizedHostTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestParameterizedHostTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestParameterizedHostTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestParameterizedHostTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestParameterizedHostTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestParameterizedHostTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestParameterizedHostTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestParameterizedHostTestClientClient"),
+        apiVersion: AutoRestParameterizedHostTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestParameterizedHostTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/extensible-enums-swagger/Source/Generated/Options/PetStoreIncClientOptions.swift
+++ b/test/integration/generated/extensible-enums-swagger/Source/Generated/Options/PetStoreIncClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `PetStoreIncClient`.
+/// User-configurable client options.
 public struct PetStoreIncClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `PetStoreIncClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `PetStoreIncClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `PetStoreIncClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `PetStoreIncClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `PetStoreIncClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: PetStoreIncClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "PetStoreIncClientClient"),
+        apiVersion: PetStoreIncClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "PetStoreInc"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/extensible-enums-swagger/Source/Generated/PetStoreIncClient.swift
+++ b/test/integration/generated/extensible-enums-swagger/Source/Generated/PetStoreIncClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class PetStoreIncClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `PetStoreIncClient`.
     public let options: PetStoreIncClientOptions
 

--- a/test/integration/generated/head/Source/Generated/AutoRestHeadTestClient.swift
+++ b/test/integration/generated/head/Source/Generated/AutoRestHeadTestClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestHeadTestClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestHeadTestClient`.
     public let options: AutoRestHeadTestClientOptions
 

--- a/test/integration/generated/head/Source/Generated/Options/AutoRestHeadTestClientOptions.swift
+++ b/test/integration/generated/head/Source/Generated/Options/AutoRestHeadTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestHeadTestClient`.
+/// User-configurable client options.
 public struct AutoRestHeadTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestHeadTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestHeadTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestHeadTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestHeadTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestHeadTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestHeadTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestHeadTestClientClient"),
+        apiVersion: AutoRestHeadTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestHeadTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/header/Source/Generated/AutoRestSwaggerBatHeaderClient.swift
+++ b/test/integration/generated/header/Source/Generated/AutoRestSwaggerBatHeaderClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestSwaggerBatHeaderClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestSwaggerBatHeaderClient`.
     public let options: AutoRestSwaggerBatHeaderClientOptions
 

--- a/test/integration/generated/header/Source/Generated/Options/AutoRestSwaggerBatHeaderClientOptions.swift
+++ b/test/integration/generated/header/Source/Generated/Options/AutoRestSwaggerBatHeaderClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestSwaggerBatHeaderClient`.
+/// User-configurable client options.
 public struct AutoRestSwaggerBatHeaderClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestSwaggerBatHeaderClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestSwaggerBatHeaderClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestSwaggerBatHeaderClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestSwaggerBatHeaderClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestSwaggerBatHeaderClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestSwaggerBatHeaderClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestSwaggerBatHeaderClientClient"),
+        apiVersion: AutoRestSwaggerBatHeaderClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestSwaggerBatHeader"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/model-flattening/Source/Generated/AutoRestResourceFlatteningTestClient.swift
+++ b/test/integration/generated/model-flattening/Source/Generated/AutoRestResourceFlatteningTestClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestResourceFlatteningTestClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestResourceFlatteningTestClient`.
     public let options: AutoRestResourceFlatteningTestClientOptions
 

--- a/test/integration/generated/model-flattening/Source/Generated/Options/AutoRestResourceFlatteningTestClientOptions.swift
+++ b/test/integration/generated/model-flattening/Source/Generated/Options/AutoRestResourceFlatteningTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestResourceFlatteningTestClient`.
+/// User-configurable client options.
 public struct AutoRestResourceFlatteningTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestResourceFlatteningTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestResourceFlatteningTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestResourceFlatteningTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestResourceFlatteningTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestResourceFlatteningTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestResourceFlatteningTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestResourceFlatteningTestClientClient"),
+        apiVersion: AutoRestResourceFlatteningTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestResourceFlatteningTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/paging/Source/Generated/AutoRestPagingTestClient.swift
+++ b/test/integration/generated/paging/Source/Generated/AutoRestPagingTestClient.swift
@@ -21,37 +21,6 @@ public final class AutoRestPagingTestClient: PipelineClient, PageableClient {
         return URL(string: token)
     }
 
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestPagingTestClient`.
     public let options: AutoRestPagingTestClientOptions
 

--- a/test/integration/generated/paging/Source/Generated/Options/AutoRestPagingTestClientOptions.swift
+++ b/test/integration/generated/paging/Source/Generated/Options/AutoRestPagingTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestPagingTestClient`.
+/// User-configurable client options.
 public struct AutoRestPagingTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestPagingTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestPagingTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestPagingTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestPagingTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestPagingTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestPagingTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestPagingTestClientClient"),
+        apiVersion: AutoRestPagingTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestPagingTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/report/Source/Generated/AutoRestReportClient.swift
+++ b/test/integration/generated/report/Source/Generated/AutoRestReportClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestReportClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestReportClient`.
     public let options: AutoRestReportClientOptions
 

--- a/test/integration/generated/report/Source/Generated/Options/AutoRestReportClientOptions.swift
+++ b/test/integration/generated/report/Source/Generated/Options/AutoRestReportClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestReportClient`.
+/// User-configurable client options.
 public struct AutoRestReportClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestReportClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestReportClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestReportClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestReportClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestReportClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestReportClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestReportClientClient"),
+        apiVersion: AutoRestReportClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestReport"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/required-optional/Source/Generated/AutoRestRequiredOptionalTestClient.swift
+++ b/test/integration/generated/required-optional/Source/Generated/AutoRestRequiredOptionalTestClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestRequiredOptionalTestClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestRequiredOptionalTestClient`.
     public let options: AutoRestRequiredOptionalTestClientOptions
 

--- a/test/integration/generated/required-optional/Source/Generated/Options/AutoRestRequiredOptionalTestClientOptions.swift
+++ b/test/integration/generated/required-optional/Source/Generated/Options/AutoRestRequiredOptionalTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestRequiredOptionalTestClient`.
+/// User-configurable client options.
 public struct AutoRestRequiredOptionalTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestRequiredOptionalTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestRequiredOptionalTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestRequiredOptionalTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestRequiredOptionalTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestRequiredOptionalTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestRequiredOptionalTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestRequiredOptionalTestClientClient"),
+        apiVersion: AutoRestRequiredOptionalTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestRequiredOptionalTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/url-multi-collectionFormat/Source/Generated/AutoRestUrlMutliCollectionFormatTestClient.swift
+++ b/test/integration/generated/url-multi-collectionFormat/Source/Generated/AutoRestUrlMutliCollectionFormatTestClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestUrlMutliCollectionFormatTestClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestUrlMutliCollectionFormatTestClient`.
     public let options: AutoRestUrlMutliCollectionFormatTestClientOptions
 

--- a/test/integration/generated/url-multi-collectionFormat/Source/Generated/Options/AutoRestUrlMutliCollectionFormatTestClientOptions.swift
+++ b/test/integration/generated/url-multi-collectionFormat/Source/Generated/Options/AutoRestUrlMutliCollectionFormatTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestUrlMutliCollectionFormatTestClient`.
+/// User-configurable client options.
 public struct AutoRestUrlMutliCollectionFormatTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestUrlMutliCollectionFormatTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestUrlMutliCollectionFormatTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestUrlMutliCollectionFormatTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestUrlMutliCollectionFormatTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestUrlMutliCollectionFormatTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestUrlMutliCollectionFormatTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestUrlMutliCollectionFormatTestClientClient"),
+        apiVersion: AutoRestUrlMutliCollectionFormatTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestUrlMutliCollectionFormatTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/url/Source/Generated/AutoRestUrlTestClient.swift
+++ b/test/integration/generated/url/Source/Generated/AutoRestUrlTestClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestUrlTestClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestUrlTestClient`.
     public let options: AutoRestUrlTestClientOptions
 

--- a/test/integration/generated/url/Source/Generated/Options/AutoRestUrlTestClientOptions.swift
+++ b/test/integration/generated/url/Source/Generated/Options/AutoRestUrlTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestUrlTestClient`.
+/// User-configurable client options.
 public struct AutoRestUrlTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestUrlTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestUrlTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestUrlTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestUrlTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestUrlTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestUrlTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestUrlTestClientClient"),
+        apiVersion: AutoRestUrlTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestUrlTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/validation/Source/Generated/AutoRestValidationTestClient.swift
+++ b/test/integration/generated/validation/Source/Generated/AutoRestValidationTestClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class AutoRestValidationTestClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version "1.0.0"
-        case v100
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v100
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v100:
-                return "1.0.0"
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "1.0.0":
-                self = .v100
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `AutoRestValidationTestClient`.
     public let options: AutoRestValidationTestClientOptions
 

--- a/test/integration/generated/validation/Source/Generated/Options/AutoRestValidationTestClientOptions.swift
+++ b/test/integration/generated/validation/Source/Generated/Options/AutoRestValidationTestClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `AutoRestValidationTestClient`.
+/// User-configurable client options.
 public struct AutoRestValidationTestClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `AutoRestValidationTestClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `AutoRestValidationTestClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version "1.0.0"
+        case v100
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v100
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v100:
+                return "1.0.0"
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "1.0.0":
+                self = .v100
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `AutoRestValidationTestClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `AutoRestValidationTestClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `AutoRestValidationTestClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: AutoRestValidationTestClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestValidationTestClientClient"),
+        apiVersion: AutoRestValidationTestClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "AutoRestValidationTest"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/xms-error-responses/Source/Generated/Options/XmsErrorResponseExtensionsClientOptions.swift
+++ b/test/integration/generated/xms-error-responses/Source/Generated/Options/XmsErrorResponseExtensionsClientOptions.swift
@@ -14,29 +14,60 @@ import Foundation
 // swiftlint:disable identifier_name
 // swiftlint:disable line_length
 
-/// User-configurable options for the `XmsErrorResponseExtensionsClient`.
+/// User-configurable client options.
 public struct XmsErrorResponseExtensionsClientOptions: ClientOptions {
-    /// The API version of the  to invoke.
+    /// The API version of the client to invoke.
     public let apiVersion: String
-    /// The `ClientLogger` to be used by this `XmsErrorResponseExtensionsClient`.
+    /// The `ClientLogger` to be used by this client.
     public let logger: ClientLogger
-    /// Options for configuring telemetry sent by this `XmsErrorResponseExtensionsClient`.
+    /// Options for configuring telemetry sent by this client.
     public let telemetryOptions: TelemetryOptions
     /// Global transport options
     public let transportOptions: TransportOptions
     /// The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public let dispatchQueue: DispatchQueue?
 
+    /// API version of the  to invoke. Defaults to the latest.
+    public enum ApiVersion: RequestStringConvertible {
+        /// Custom value for unrecognized enum values
+        case custom(String)
+        /// API version ""
+        case v
+
+        /// The most recent API version of the
+        public static var latest: ApiVersion {
+            return .v
+        }
+
+        public var requestString: String {
+            switch self {
+            case let .custom(val):
+                return val
+            case .v:
+                return ""
+            }
+        }
+
+        public init(_ val: String) {
+            switch val.lowercased() {
+            case "":
+                self = .v
+            default:
+                self = .custom(val)
+            }
+        }
+    }
+
     /// Initialize a `XmsErrorResponseExtensionsClientOptions` structure.
     /// - Parameters:
-    ///   - apiVersion: The API version of the  to invoke.
-    ///   - logger: The `ClientLogger` to be used by this `XmsErrorResponseExtensionsClient`.
-    ///   - telemetryOptions: Options for configuring telemetry sent by this `XmsErrorResponseExtensionsClient`.
+    ///   - apiVersion: The API version of the client to invoke.
+    ///   - logger: The `ClientLogger` to be used by this client.
+    ///   - telemetryOptions: Options for configuring telemetry sent by this client.
     ///   - cancellationToken: A token used to make a best-effort attempt at canceling a request.
     ///   - dispatchQueue: The default dispatch queue on which to call all completion handler. Defaults to `DispatchQueue.main`.
     public init(
-        apiVersion: XmsErrorResponseExtensionsClient.ApiVersion = .latest,
-        logger: ClientLogger = ClientLoggers.default(tag: "XmsErrorResponseExtensionsClientClient"),
+        apiVersion: XmsErrorResponseExtensionsClientOptions.ApiVersion = .latest,
+        logger: ClientLogger = ClientLoggers.default(tag: "XmsErrorResponseExtensions"),
         telemetryOptions: TelemetryOptions = TelemetryOptions(),
         transportOptions: TransportOptions? = nil,
         dispatchQueue: DispatchQueue? = nil

--- a/test/integration/generated/xms-error-responses/Source/Generated/XmsErrorResponseExtensionsClient.swift
+++ b/test/integration/generated/xms-error-responses/Source/Generated/XmsErrorResponseExtensionsClient.swift
@@ -17,37 +17,6 @@ import Foundation
 // swiftlint:disable type_body_length
 
 public final class XmsErrorResponseExtensionsClient: PipelineClient {
-    /// API version of the  to invoke. Defaults to the latest.
-    public enum ApiVersion: RequestStringConvertible {
-        /// Custom value for unrecognized enum values
-        case custom(String)
-        /// API version ""
-        case v
-
-        /// The most recent API version of the
-        public static var latest: ApiVersion {
-            return .v
-        }
-
-        public var requestString: String {
-            switch self {
-            case let .custom(val):
-                return val
-            case .v:
-                return ""
-            }
-        }
-
-        public init(_ val: String) {
-            switch val.lowercased() {
-            case "":
-                self = .v
-            default:
-                self = .custom(val)
-            }
-        }
-    }
-
     /// Options provided to configure this `XmsErrorResponseExtensionsClient`.
     public let options: XmsErrorResponseExtensionsClientOptions
 


### PR DESCRIPTION
This change helps ensure that aliased, internal models are generated only in other internal models. For example, if `Foo` model were aliased to `FooInternal`, then autorest would generate the following for objects that referenced `Foo`:

```swift
// Uses the "unaliased" name that the developer must custom-write
public struct PublicObject {
  public let foo: Foo
}

// Uses the aliased name of the generated model
internal struct InternalObject {
  internal let foo: FooInternal
}
```

- The changes looks at the containing object's visibility to decide whether to inject the public (custom) name or the internal (generated) one.

- Client options are generated with independent visibility instead of inheriting the client's visibility.

- ApiVersion is now generated as part of ClientOptions instead of as part of the Client. This is a **breaking change**.

cc/ @Leoaqr