### PR TITLE
Invoke CompletionHandler as .failure if status code is not legit.

### DIFF
--- a/templates/Operation_Response_Body_Snippet.stencil
+++ b/templates/Operation_Response_Body_Snippet.stencil
@@ -62,4 +62,8 @@
 {% else %}
     // TODO: Couldn't find template for {response.strategy}
 {% endif %}
+} else {
+    dispatchQueue.async {
+        completionHandler(.failure(AzureError.service(httpResponse?.statusMessage ?? "")), httpResponse)
+    }
 }


### PR DESCRIPTION
Currently generated client won't invoke CompletionHandler if the status code is not legit. 