### PR TITLE
Hand off @ronniegeraghty CODEOWNERS to new owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,5 @@
 ################
 
 # Git Hub bot rules
-/.github/CODEOWNERS  @jsquire @ronniegeraghty
-/.github/fabricbot.json  @jsquire @ronniegeraghty
+/.github/CODEOWNERS  @jsquire
+/.github/fabricbot.json  @jsquire


### PR DESCRIPTION
## Summary

Removing `@ronniegeraghty` from `.github/CODEOWNERS` as Ronnie transitions from the Azure SDK / Tools portfolio into a different role.

## What changed

See the diff. For lines where removing Ronnie would leave fewer than one human owner, a replacement was added per discussion with Ronnie. All other lines simply drop his alias.

## Reviewers

Tagging the existing co-owners on the affected lines for review.

## Related

- Workitem: Azure/projects/424 - "Review CODEOWNERS entries in SDK repos, transfer to right new owner"
- Full handoff plan: internal doc `projects/sdk-team-brain-dump/codeowners-handoff/README.md` in `ronniegeraghty/ronnies-agent-team`

---
*Opened as part of the Azure SDK handoff. Marking as draft until Ronnie reviews; flip to ready-for-review once approved internally.*
